### PR TITLE
Remame MEILISEARCH_MASTER_KEY env variable into MEILISEARCH_API_KEY

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
         <env name="APP_DEBUG" value="false"/>
         <env name="MEILISEARCH_PREFIX" value="sf_phpunit_"/>
         <env name="MEILISEARCH_URL" value="http://127.0.0.1:7700"/>
-        <env name="MEILISEARCH_MASTER_KEY" value="masterKey"/>
+        <env name="MEILISEARCH_API_KEY" value="masterKey"/>
         <env name="TRAVIS_JOB_NUMBER" value=""/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
     </php>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -21,7 +21,7 @@
 
         <service id="search.client" class="MeiliSearch\Client" public="true" lazy="true">
             <argument key="$url">%env(MEILISEARCH_URL)%</argument>
-            <argument key="$api_key">%env(MEILISEARCH_MASTER_KEY)%</argument>
+            <argument key="$api_key">%env(MEILISEARCH_API_KEY)%</argument>
         </service>
 
         <service id="MeiliSearch\Client" alias="search.client"/>


### PR DESCRIPTION
Passing a master key is not mandatory since MeiliSearch can accept private or public in the header as an API key.
See this [related documentation](https://docs.meilisearch.com/guides/advanced_guides/authentication.html#authentication).

⚠️ The Wiki needs to be updated