### PR TITLE
Removing document issue, send documentId instead of array

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ $ composer lint:check
 
 ### Using the Docker Environment
 
-These commands do not work on MacOS, see [this issue](https://github.com/meilisearch/meilisearch-symfony/).
+These commands do not work on MacOS, see [this issue](https://github.com/meilisearch/meilisearch-symfony/issues/6).
 
 #### Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ $ composer test:unit
 # Linter
 $ composer lint:check
 # Linter (with auto-fix)
-$ composer lint:check
+$ composer lint:fix
 ```
 
 ### Using the Docker Environment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,31 +29,6 @@ First of all, thank you for contributing to MeiliSearch! The goal of this docume
 
 ## Development Workflow
 
-### Using the Docker Environment
-
-#### Setup
-
-To start and build your Docker environment, just execute the next command in a terminal:
-
-```sh
-$ docker-compose up -d
-```
-
-Be sure no other MeiliSearch instance is currently running on your machine.
-
-#### Tests and Linter
-
-Each Pull Request should pass the tests, and the linter to be accepted.
-
-```sh
-# Tests
-$ docker-compose exec -e MEILISEARCH_URL=http://meilisearch:7700 php composer test:unit
-# Linter
-$ docker-compose exec php composer lint:check
-# Linter (with auto-fix)
-$ docker-compose exec php composer lint:fix
-```
-
 ### Using Composer
 
 #### Setup
@@ -76,6 +51,33 @@ $ composer test:unit
 $ composer lint:check
 # Linter (with auto-fix)
 $ composer lint:check
+```
+
+### Using the Docker Environment
+
+These commands do not work on MacOS, see [this issue](https://github.com/meilisearch/meilisearch-symfony/).
+
+#### Setup
+
+To start and build your Docker environment, just execute the next command in a terminal:
+
+```sh
+$ docker-compose up -d
+```
+
+Be sure no other MeiliSearch instance is currently running on your machine.
+
+#### Tests and Linter
+
+Each Pull Request should pass the tests, and the linter to be accepted.
+
+```sh
+# Tests
+$ docker-compose exec -e MEILISEARCH_URL=http://meilisearch:7700 php composer test:unit
+# Linter
+$ docker-compose exec php composer lint:check
+# Linter (with auto-fix)
+$ docker-compose exec php composer lint:fix
 ```
 
 ### Release Process

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,8 @@ RUN set -eux; \
 COPY src src/
 COPY tests tests/
 
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
+ENTRYPOINT ["docker-entrypoint"]
 CMD ["php-fpm"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 
 This package is compatible with the following MeiliSearch versions:
 
+- `v0.13.X`
 - `v0.12.X`
 - `v0.11.X`
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "meilisearch/meilisearch-php": "^0.12",
+        "meilisearch/meilisearch-php": "^0.13",
         "symfony/filesystem": "^4.0 || ^5.0",
         "symfony/property-access": "^4.0 || ^5.0",
         "symfony/serializer": "^4.0 || ^5.0"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+  set -- php-fpm "$@"
+fi
+
+if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
+  mkdir -p var/cache var/log
+  setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
+  setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
+
+  if [ "$APP_ENV" != 'prod' ]; then
+    composer install --prefer-dist --no-progress --no-suggest --no-interaction
+  fi
+fi
+
+exec docker-php-entrypoint "$@"

--- a/src/Command/MeiliSearchClearCommand.php
+++ b/src/Command/MeiliSearchClearCommand.php
@@ -33,12 +33,12 @@ final class MeiliSearchClearCommand extends IndexCommand
         foreach ($indexToClear as $indexName => $entity) {
             $className = $entity['name'];
             $array = $this->searchService->clear($className);
-            if ('processed' === $array['status']) {
+            if ('failed' === $array['status']) {
+                $output->writeln('<error>Index <info>'.$indexName.'</info>  couldn\'t be cleared</error>');
+            } else {
                 $output->writeln(
                     'Cleared <info>'.$indexName.'</info> index of <comment>'.$className.'</comment> '
                 );
-            } else {
-                $output->writeln('<error>Index <info>'.$indexName.'</info>  couldn\'t be cleared</error>');
             }
         }
 

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -6,6 +6,7 @@ use MeiliSearch\Client;
 use MeiliSearch\Exceptions\HTTPRequestException;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use function count;
+use function reset;
 
 /**
  * Class Engine.
@@ -106,7 +107,7 @@ final class Engine
         foreach ($data as $indexName => $objects) {
             $result[$indexName] = $this->client
                 ->getIndex($indexName)
-                ->deleteDocument($objects);
+                ->deleteDocument(reset($objects));
         }
 
         return $result;

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -153,6 +153,10 @@ final class Engine
      */
     public function search(string $query, string $indexName, array $requestOptions): array
     {
+        if ('' === $query) {
+            $query = null;
+        }
+
         return $this->client->getIndex($indexName)->search($query, $requestOptions);
     }
 

--- a/src/MeiliSearchBundle.php
+++ b/src/MeiliSearchBundle.php
@@ -11,5 +11,5 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class MeiliSearchBundle extends Bundle
 {
-    const VERSION = '0.2.0';
+    const VERSION = '0.2.2';
 }

--- a/tests/TestCase/CommandsTest.php
+++ b/tests/TestCase/CommandsTest.php
@@ -13,8 +13,8 @@ use MeiliSearch\Bundle\Test\Entity\Comment;
 use MeiliSearch\Bundle\Test\Entity\ContentAggregator;
 use MeiliSearch\Bundle\Test\Entity\Post;
 use MeiliSearch\Client;
+use MeiliSearch\Endpoints\Indexes;
 use MeiliSearch\Exceptions\HTTPRequestException;
-use MeiliSearch\Index;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -47,7 +47,7 @@ class CommandsTest extends BaseTest
     /** @var AbstractPlatform|null $platform */
     protected $platform;
 
-    /** @var Index $index */
+    /** @var Indexes $index */
     protected $index;
 
     /**

--- a/tests/TestCase/SettingsTest.php
+++ b/tests/TestCase/SettingsTest.php
@@ -63,9 +63,9 @@ class SettingsTest extends BaseTest
         $this->assertEquals(self::DEFAULT_RANKING_RULES, $settingA['rankingRules']);
         $this->assertNull($settingA['distinctAttribute']);
         $this->assertIsArray($settingA['searchableAttributes']);
-        $this->assertEquals(['*'], $settingA['searchableAttributes']);
+        $this->assertEquals([], $settingA['searchableAttributes']);
         $this->assertIsArray($settingA['displayedAttributes']);
-        $this->assertEquals(['*'], $settingA['displayedAttributes']);
+        $this->assertEquals([], $settingA['displayedAttributes']);
         $this->assertIsArray($settingA['stopWords']);
         $this->assertEmpty($settingA['stopWords']);
         $this->assertIsArray($settingA['synonyms']);
@@ -73,8 +73,8 @@ class SettingsTest extends BaseTest
 
         $this->assertEquals(self::DEFAULT_RANKING_RULES, $settingB['rankingRules']);
         $this->assertNull($settingB['distinctAttribute']);
-        $this->assertEquals(['*'], $settingB['searchableAttributes']);
-        $this->assertEquals(['*'], $settingB['displayedAttributes']);
+        $this->assertEquals(['ObjectID'], $settingB['searchableAttributes']);
+        $this->assertEquals(['ObjectID'], $settingB['displayedAttributes']);
         $this->assertIsArray($settingB['stopWords']);
         $this->assertEmpty($settingB['stopWords']);
         $this->assertIsArray($settingB['synonyms']);

--- a/tests/TestCase/SettingsTest.php
+++ b/tests/TestCase/SettingsTest.php
@@ -63,24 +63,22 @@ class SettingsTest extends BaseTest
         $this->assertEquals(self::DEFAULT_RANKING_RULES, $settingA['rankingRules']);
         $this->assertNull($settingA['distinctAttribute']);
         $this->assertIsArray($settingA['searchableAttributes']);
-        $this->assertEmpty($settingA['searchableAttributes']);
+        $this->assertEquals(['*'], $settingA['searchableAttributes']);
         $this->assertIsArray($settingA['displayedAttributes']);
-        $this->assertEmpty($settingA['displayedAttributes']);
+        $this->assertEquals(['*'], $settingA['displayedAttributes']);
         $this->assertIsArray($settingA['stopWords']);
         $this->assertEmpty($settingA['stopWords']);
         $this->assertIsArray($settingA['synonyms']);
         $this->assertEmpty($settingA['synonyms']);
-        $this->assertTrue($settingA['acceptNewFields']);
 
         $this->assertEquals(self::DEFAULT_RANKING_RULES, $settingB['rankingRules']);
         $this->assertNull($settingB['distinctAttribute']);
-        $this->assertEquals([$primaryKey], $settingB['searchableAttributes']);
-        $this->assertEquals([$primaryKey], $settingB['displayedAttributes']);
+        $this->assertEquals(['*'], $settingB['searchableAttributes']);
+        $this->assertEquals(['*'], $settingB['displayedAttributes']);
         $this->assertIsArray($settingB['stopWords']);
         $this->assertEmpty($settingB['stopWords']);
         $this->assertIsArray($settingB['synonyms']);
         $this->assertEmpty($settingB['synonyms']);
-        $this->assertTrue($settingB['acceptNewFields']);
     }
 
     public function testUpdateSettings()

--- a/tests/TestCase/SettingsTest.php
+++ b/tests/TestCase/SettingsTest.php
@@ -73,8 +73,8 @@ class SettingsTest extends BaseTest
 
         $this->assertEquals(self::DEFAULT_RANKING_RULES, $settingB['rankingRules']);
         $this->assertNull($settingB['distinctAttribute']);
-        $this->assertEquals(['ObjectID'], $settingB['searchableAttributes']);
-        $this->assertEquals(['ObjectID'], $settingB['displayedAttributes']);
+        $this->assertEquals(['*'], $settingB['searchableAttributes']);
+        $this->assertEquals(['*'], $settingB['displayedAttributes']);
         $this->assertIsArray($settingB['stopWords']);
         $this->assertEmpty($settingB['stopWords']);
         $this->assertIsArray($settingB['synonyms']);

--- a/tests/TestCase/SettingsTest.php
+++ b/tests/TestCase/SettingsTest.php
@@ -63,9 +63,9 @@ class SettingsTest extends BaseTest
         $this->assertEquals(self::DEFAULT_RANKING_RULES, $settingA['rankingRules']);
         $this->assertNull($settingA['distinctAttribute']);
         $this->assertIsArray($settingA['searchableAttributes']);
-        $this->assertEquals([], $settingA['searchableAttributes']);
+        $this->assertEquals(['*'], $settingA['searchableAttributes']);
         $this->assertIsArray($settingA['displayedAttributes']);
-        $this->assertEquals([], $settingA['displayedAttributes']);
+        $this->assertEquals(['*'], $settingA['displayedAttributes']);
         $this->assertIsArray($settingA['stopWords']);
         $this->assertEmpty($settingA['stopWords']);
         $this->assertIsArray($settingA['synonyms']);


### PR DESCRIPTION
When trying to remove a document from MeiliSearch indices, code sent to `deleteDocument()` method was:
```
[0 => "003cedf8fec53ae9a0edb79a303e17a1"]
```

Since the `\MeiliSearch\Endpoints\Delegates\HandlesDocuments::deleteDocument` need a `$documentId` of type **int/string** this was returning an error.

This PR fix this behavior
