### PR TITLE
Changes about the MeiliSearch's next release (v0.16.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 ## 🤖 Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
+This package only guarantees the compatibility with the [version v0.16.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.16.0).
 
 ## ✨ Features
 


### PR DESCRIPTION
- [x] Update README
- [x] Use the new version of `meilisearch-php` as a dependency (https://github.com/meilisearch/meilisearch-php/pull/111 should be merged before) -> **the new version of `meilisearch-php` ([v0.15.1](https://github.com/meilisearch/meilisearch-php/releases/tag/v0.15.1)) is not breaking so no need to change `composer.json`**

This PR:
- gathers the changes related to the next release of MeiliSearch (v0.16.0) so that this package is ready when the official release is out.
- should pass the tests against the [latest pre-release of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases). This should be tested locally.
- might eventually fail until the MeiliSearch v0.16.0 is out.

⚠️ This PR should NOT be merged until the MeiliSearch's next release (v0.16.0) is out.