### PR TITLE
Rename requestOptions to searchParams

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -166,12 +166,12 @@ final class Engine
      *
      * @param string $query
      * @param string $indexName
-     * @param array  $requestOptions
+     * @param array  $searchParams
      *
      * @return int
      */
-    public function count(string $query, string $indexName, array $requestOptions): int
+    public function count(string $query, string $indexName, array $searchParams): int
     {
-        return (int) $this->client->index($indexName)->search($query, $requestOptions)['nbHits'];
+        return (int) $this->client->index($indexName)->search($query, $searchParams)['nbHits'];
     }
 }

--- a/src/SearchService.php
+++ b/src/SearchService.php
@@ -71,7 +71,7 @@ interface SearchService
      * @param ObjectManager $objectManager
      * @param string        $className
      * @param string        $query
-     * @param array         $requestOptions
+     * @param array         $searchParams
      *
      * @return array
      */
@@ -79,7 +79,7 @@ interface SearchService
         ObjectManager $objectManager,
         string $className,
         string $query = '',
-        array $requestOptions = []
+        array $searchParams = []
     ): array;
 
     /**
@@ -102,9 +102,9 @@ interface SearchService
     /**
      * @param string $className
      * @param string $query
-     * @param array  $requestOptions
+     * @param array  $searchParams
      *
      * @return int
      */
-    public function count(string $className, string $query = '', array $requestOptions = []): int;
+    public function count(string $className, string $query = '', array $searchParams = []): int;
 }

--- a/src/Services/MeiliSearchService.php
+++ b/src/Services/MeiliSearchService.php
@@ -209,11 +209,11 @@ final class MeiliSearchService implements SearchService
         ObjectManager $objectManager,
         string $className,
         string $query = '',
-        array $requestOptions = []
+        array $searchParams = []
     ): array {
         $this->assertIsSearchable($className);
 
-        $ids = $this->engine->search($query, $this->searchableAs($className), $requestOptions);
+        $ids = $this->engine->search($query, $this->searchableAs($className), $searchParams);
         $results = [];
 
         // Check if the engine returns results in "hits" key
@@ -257,11 +257,11 @@ final class MeiliSearchService implements SearchService
     /**
      * {@inheritdoc}
      */
-    public function count(string $className, string $query = '', array $requestOptions = []): int
+    public function count(string $className, string $query = '', array $searchParams = []): int
     {
         $this->assertIsSearchable($className);
 
-        return $this->engine->count($query, $this->searchableAs($className), $requestOptions);
+        return $this->engine->count($query, $this->searchableAs($className), $searchParams);
     }
 
     /**

--- a/src/Services/NullSearchService.php
+++ b/src/Services/NullSearchService.php
@@ -84,7 +84,7 @@ class NullSearchService implements SearchService
         ObjectManager $objectManager,
         string $className,
         string $query = '',
-        array $requestOptions = []
+        array $searchParams = []
     ): array {
         return [new stdClass()];
     }
@@ -103,7 +103,7 @@ class NullSearchService implements SearchService
     /**
      * {@inheritdoc}
      */
-    public function count(string $className, string $query = '', array $requestOptions = []): int
+    public function count(string $className, string $query = '', array $searchParams = []): int
     {
         return 0;
     }


### PR DESCRIPTION
This PR renames the `requestOptions` variable to `searchParams`, see #58.