### PR TITLE
Add dependabot, run check on workflow versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+    # Workflow files stored in the
+    - package-ecosystem: "github-actions"
+      commit-message:
+          include: "scope"
+          prefix: "github-actions"
+        # default location of `.github/workflows`
+      directory: "/"
+      open-pull-requests-limit: 10
+      schedule:
+          interval: "daily"


### PR DESCRIPTION
This PR adds [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) support. It runs checks for the [`github-actions`](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#package-ecosystem) to keep the versions up-to-date.