### PR TITLE
Refactor deprecated doctrine methods

### DIFF
--- a/src/Command/MeiliSearchImportCommand.php
+++ b/src/Command/MeiliSearchImportCommand.php
@@ -154,10 +154,9 @@ final class MeiliSearchImportCommand extends IndexCommand
                 }
 
                 ++$page;
-                $repository->clear();
             } while (count($entities) >= $config['batchSize']);
 
-            $repository->clear();
+            $manager->clear();
         }
 
         $output->writeln('<info>Done!</info>');


### PR DESCRIPTION
Closes #74 

This PR replaces the deprecated `clear()` methods for Doctrines `EntityRepository` with a `clear` call on the `EntityManager`. 