### PR TITLE
Add url api key config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Also, see our [Documentation](https://docs.meilisearch.com/learn/tutorials/getti
 
 ## 📝 Requirements
 
-* **Require** PHP 7.2 and later.
+* **Require** PHP 7.4 and later.
 * **Compatible** with Symfony 4.0 and later.
 * **Support** Doctrine ORM and Doctrine MongoDB.
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,6 +19,8 @@ final class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->scalarNode('url')->end()
+                ->scalarNode('api_key')->end()
                 ->scalarNode('prefix')
                     ->defaultValue(null)
                 ->end()

--- a/src/DependencyInjection/MeiliSearchExtension.php
+++ b/src/DependencyInjection/MeiliSearchExtension.php
@@ -33,6 +33,9 @@ final class MeiliSearchExtension extends Extension
             $config['prefix'] = $container->getParameter('kernel.environment').'_';
         }
 
+        $container->setParameter('meili_url', $config['url']);
+        $container->setParameter('meili_api_key', $config['api_key']);
+
         if (\count($doctrineSubscribedEvents = $config['doctrineSubscribedEvents']) > 0) {
             $container->getDefinition('search.search_indexer_subscriber')->setArgument(1, $doctrineSubscribedEvents);
         } else {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -20,8 +20,8 @@
         </service>
 
         <service id="search.client" class="MeiliSearch\Client" public="true" lazy="true">
-            <argument key="$url">%env(MEILISEARCH_URL)%</argument>
-            <argument key="$apiKey">%env(MEILISEARCH_API_KEY)%</argument>
+            <argument key="$url">%meili_url%</argument>
+            <argument key="$apiKey">%meili_api_key%</argument>
         </service>
 
         <service id="MeiliSearch\Client" alias="search.client"/>

--- a/tests/config/meili_search.yaml
+++ b/tests/config/meili_search.yaml
@@ -1,4 +1,6 @@
 meili_search:
+    url: '%env(MEILISEARCH_URL)%'
+    api_key: '%env(MEILISEARCH_API_KEY)%'
     prefix: '%env(MEILISEARCH_PREFIX)%_'
     nbResults: 12
     batchSize: 100


### PR DESCRIPTION
Currently the URL and API_KEY was read via `%env(MEILISEARCH_URL)%` in `services.xml`. This does not fulfill the requirements for a Symfony recipe - see [PR](https://github.com/symfony/recipes-contrib/pull/1128).

This PR moves the configuration of `url` and `api_key` into the `config/meili_search.yml` file, and references the env helper `%env(MEILISEARCH_URL)%` and `%env(MEILISEARCH_API_KEY)%` in there.

This is a breaking change, as the config now _must_ look like:

```yml
meili_search:
  url: '%env(MEILISEARCH_URL)%'
  api_key: '%env(MEILISEARCH_API_KEY)%'
  prefix: '%env(MEILISEARCH_PREFIX)%'
  # Further settings
```

... see `url` and `api_key`. 

For existing projects these two keys need to be added to the config manually. When the Symfony recipe is approved thise file will be created automatically and populated with the necessary values.