### PR TITLE
Ensure scalar object-ID is used for fetching entities

### DIFF
--- a/src/Exception/ObjectIdNotFoundException.php
+++ b/src/Exception/ObjectIdNotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Bundle\Exception;
+
+/**
+ * Class ObjectIdNotFoundException.
+ */
+final class ObjectIdNotFoundException extends \LogicException
+{
+}

--- a/src/SearchService.php
+++ b/src/SearchService.php
@@ -11,6 +11,9 @@ use Doctrine\Persistence\ObjectManager;
  */
 interface SearchService
 {
+    public const RESULT_KEY_HITS = 'hits';
+    public const RESULT_KEY_OBJECTID = 'objectID';
+
     /**
      * @param string|object $className
      */


### PR DESCRIPTION
There currently is a bug in how the search-service retrieves the entities from the results returned from the engine.

It falsely assumes that what it gets back from the engine is a list of object-IDs, when it actually is a list of arrays holding the indexed data for the objects matching the query.

This entire array is passed to `findOneBy`, which expands the `IN(?)`-criteria to a list `IN(?,?,?)`, where the parameters are bound to all indexed properties. This leads to the same entity being returned multiple times, rather than different entities being directly adressed through the scalar object-ID.

A test case illustrates this behaviour, where the Post-contents match the object-ID "1". This test case fails on the current 0.3.0, and passes with the fix proposed in this PR.