### PR TITLE
Remove jms serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.3",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "jms/serializer-bundle": "^3.0",
         "nyholm/psr7": "^1.3",
         "phpunit/phpunit": "^9.5",
         "symfony/doctrine-bridge": "^4.0 || ^5.0",

--- a/src/SearchableEntity.php
+++ b/src/SearchableEntity.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MeiliSearch\Bundle;
 
 use Doctrine\Persistence\Mapping\ClassMetadata;
-use JMS\Serializer\ArrayTransformerInterface;
+use MeiliSearch\Bundle\Exception\UnknownNormalizerException;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -70,8 +70,6 @@ final class SearchableEntity
 
         if ($this->normalizer instanceof NormalizerInterface) {
             return $this->normalizer->normalize($this->entity, Searchable::NORMALIZATION_FORMAT, $context);
-        } elseif ($this->normalizer instanceof ArrayTransformerInterface) {
-            return $this->normalizer->toArray($this->entity);
         }
 
         return [];

--- a/src/SearchableEntity.php
+++ b/src/SearchableEntity.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MeiliSearch\Bundle;
 
 use Doctrine\Persistence\Mapping\ClassMetadata;
-use MeiliSearch\Bundle\Exception\UnknownNormalizerException;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;


### PR DESCRIPTION
This PR remove the `jms/serializer` package. The serializer used by `melisearch-symfony` is [Symfonys Serializer Component](https://symfony.com/doc/current/components/serializer.html).

I think the usage of jms/serilaizer was a left-over from somewhen, as the normalizer cannot be different to the `NormalizerInterface` coming from Symfonys component.

Further the `jms/serializer` component was added in the `require-dev` section which indicates that the package was used for testing/developing purposes. I wasn't able to spot any usage.