### PR TITLE
Install fails, autowiring manager registry fails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "symfony/serializer": "^4.0 || ^5.0"
     },
     "require-dev": {
+        "doctrine/orm": "^2.9",
         "friendsofphp/php-cs-fixer": "^3.0",
         "jms/serializer-bundle": "^3.0",
         "nyholm/psr7": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,13 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "doctrine/orm": "^2.8",
+        "doctrine/doctrine-bundle": "^2.4",
         "meilisearch/meilisearch-php": "^0.18",
         "symfony/filesystem": "^4.0 || ^5.0",
         "symfony/property-access": "^4.0 || ^5.0",
         "symfony/serializer": "^4.0 || ^5.0"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "^2.3",
         "friendsofphp/php-cs-fixer": "^3.0",
         "jms/serializer-bundle": "^3.0",
         "nyholm/psr7": "^1.3",

--- a/src/Command/MeiliSearchImportCommand.php
+++ b/src/Command/MeiliSearchImportCommand.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Bundle\Command;
 
+use Doctrine\Persistence\ManagerRegistry;
 use MeiliSearch\Bundle\Exception\InvalidSettingName;
 use MeiliSearch\Bundle\Exception\UpdateException;
 use MeiliSearch\Bundle\Model\Aggregator;
 use MeiliSearch\Bundle\SearchService;
 use MeiliSearch\Client;
-use Symfony\Bridge\Doctrine\ManagerRegistry;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Command/MeiliSearchImportCommand.php
+++ b/src/Command/MeiliSearchImportCommand.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Bundle\Command;
 
-use Doctrine\Persistence\ManagerRegistry;
 use MeiliSearch\Bundle\Exception\InvalidSettingName;
 use MeiliSearch\Bundle\Exception\UpdateException;
 use MeiliSearch\Bundle\Model\Aggregator;
 use MeiliSearch\Bundle\SearchService;
 use MeiliSearch\Client;
+use Symfony\Bridge\Doctrine\ManagerRegistry;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;


### PR DESCRIPTION
This PR fixes a problem with the current installation of the package.

## How to reproduce

1. Create a new project with Symfony Flex.
2. Then run `composer req "meilisearch/search-bundle:^0.3"`

This will create an error like this:

```
Run composer recipes at any time to see the status of your Symfony recipes.

Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!
!!  In DefinitionErrorExceptionPass.php line 54:
!!
!!    Cannot autowire service "MeiliSearch\Bundle\Command\MeiliSearchImportComman
!!    d": argument "$managerRegistry" of method "__construct()" references interf
!!    ace "Doctrine\Persistence\ManagerRegistry" but no such service exists. Did
!!    you create a class that implements this interface?
!!
!!
!!
Script @auto-scripts was called via post-update-cmd
```

## The solution

Using [Symfonys Doctrine Bundle](https://symfony.com/doc/current/bundles/DoctrineBundle/index.html).

This PR further adds the bundle to the `require` section, and not only to the `require-dev` section, as `meilisearch-symfony` uses this package not only for development purposes. 

Doctrines ORM package is only required for development purposes of this package.