### PR TITLE
Add option to meili:import command to override batch size

### DIFF
--- a/src/Command/MeiliSearchImportCommand.php
+++ b/src/Command/MeiliSearchImportCommand.php
@@ -40,7 +40,8 @@ final class MeiliSearchImportCommand extends IndexCommand
                 null,
                 InputOption::VALUE_NONE,
                 'Update settings related to indices to the search engine'
-            );
+            )
+            ->addOption('batch-size', null, InputOption::VALUE_REQUIRED);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -64,6 +65,8 @@ final class MeiliSearchImportCommand extends IndexCommand
         }
 
         $entitiesToIndex = array_unique($indexes->toArray(), SORT_REGULAR);
+        $batchSize = $input->getOption('batch-size');
+        $batchSize = ctype_digit($batchSize) ? (int) $batchSize : $config->get('batchSize');
 
         /** @var array $index */
         foreach ($entitiesToIndex as $index) {
@@ -82,8 +85,8 @@ final class MeiliSearchImportCommand extends IndexCommand
                 $entities = $repository->findBy(
                     [],
                     null,
-                    $config->get('batchSize'),
-                    $config->get('batchSize') * $page
+                    $batchSize,
+                    $batchSize * $page
                 );
 
                 $responses = $this->formatIndexingResponse($this->searchService->index($manager, $entities));
@@ -125,7 +128,7 @@ final class MeiliSearchImportCommand extends IndexCommand
                 }
 
                 ++$page;
-            } while (count($entities) >= $config->get('batchSize'));
+            } while (count($entities) >= $batchSize);
 
             $manager->clear();
         }

--- a/tests/Integration/CommandsTest.php
+++ b/tests/Integration/CommandsTest.php
@@ -128,6 +128,34 @@ Done!
 EOD, $clearOutput);
     }
 
+    public function testSearchImportWithCustomBatchSize(): void
+    {
+        for ($i = 0; $i <= 10; ++$i) {
+            $this->createPage($i);
+        }
+
+        $importCommand = $this->application->find('meili:import');
+        $importCommandTester = new CommandTester($importCommand);
+        $importCommandTester->execute([
+            '--indices' => 'pages',
+            '--batch-size' => '2',
+        ]);
+
+        $importOutput = $importCommandTester->getDisplay();
+
+        $this->assertSame(<<<'EOD'
+Importing for index MeiliSearch\Bundle\Test\Entity\Page
+Indexed 2 / 2 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Indexed 2 / 2 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Indexed 2 / 2 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Indexed 2 / 2 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Indexed 2 / 2 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Indexed 1 / 1 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Done!
+
+EOD, $importOutput);
+    }
+
     /**
      * Importing 'Tag' and 'Link' into the same 'tags' index.
      */


### PR DESCRIPTION
# Pull Request

## What does this PR do?

Allows to optionally provide --batch-size option to `meili:import` to use different batch size for some indices than configured in bundle config.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

