### PR TITLE
Update meilisearch-php to work with v0.24.0 of MeiliSearch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-json": "*",
         "doctrine/doctrine-bundle": "^2.4",
         "illuminate/collections": "^8.47",
-        "meilisearch/meilisearch-php": "^0.19",
+        "meilisearch/meilisearch-php": "^0.20",
         "symfony/filesystem": "^4.0 || ^5.0",
         "symfony/property-access": "^4.0 || ^5.0",
         "symfony/serializer": "^4.0 || ^5.0"

--- a/src/MeiliSearchBundle.php
+++ b/src/MeiliSearchBundle.php
@@ -11,5 +11,5 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class MeiliSearchBundle extends Bundle
 {
-    public const VERSION = '0.4.5';
+    public const VERSION = '0.5.0';
 }


### PR DESCRIPTION
Contrary to what I said here https://github.com/meilisearch/meilisearch-symfony/pull/123#pullrequestreview-808693633, to be compatible with v0.24.0, meilisearch-php involves breaking changes for the users using MeiliSearch v0.23.1 or older.
We need to use meilisearch-php v0.20.0 that has just been released

So to be compatible with MeiliSearch v0.24.0, we need to release a new minor of this package.