### PR TITLE
Add command to create indexes without importing documents

### DIFF
--- a/src/Command/MeiliSearchCreateCommand.php
+++ b/src/Command/MeiliSearchCreateCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Bundle\Command;
+
+use MeiliSearch\Bundle\Exception\InvalidSettingName;
+use MeiliSearch\Bundle\Exception\UpdateException;
+use MeiliSearch\Bundle\Model\Aggregator;
+use MeiliSearch\Bundle\SearchService;
+use MeiliSearch\Client;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class MeiliSearchCreateCommand extends IndexCommand
+{
+    protected static $defaultName = 'meili:create';
+
+    private Client $searchClient;
+
+    public function __construct(SearchService $searchService, Client $searchClient)
+    {
+        parent::__construct($searchService);
+
+        $this->searchClient = $searchClient;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Create indexes')
+            ->addOption('indices', 'i', InputOption::VALUE_OPTIONAL, 'Comma-separated list of index names');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $indexes = $this->getEntitiesFromArgs($input, $output);
+
+        foreach ($indexes as $key => $index) {
+            $entityClassName = $index['class'];
+            if (is_subclass_of($entityClassName, Aggregator::class)) {
+                $indexes->forget($key);
+
+                $indexes = collect(array_merge(
+                    $indexes->toArray(),
+                    array_map(
+                        static fn ($entity) => ['name' => $index['name'], 'class' => $entity],
+                        $entityClassName::getEntities()
+                    )
+                ));
+            }
+        }
+
+        $entitiesToIndex = array_unique($indexes->toArray(), SORT_REGULAR);
+
+        /** @var array $index */
+        foreach ($entitiesToIndex as $index) {
+            $entityClassName = $index['class'];
+
+            if (!$this->searchService->isSearchable($entityClassName)) {
+                continue;
+            }
+
+            $output->writeln('<info>Creating index '.$index['name'].' for '.$entityClassName.'</info>');
+
+            $indexInstance = $this->searchClient->getOrCreateIndex($index['name']);
+
+            if (isset($index['settings']) && is_array($index['settings'])) {
+                foreach ($index['settings'] as $variable => $value) {
+                    $method = sprintf('update%s', ucfirst($variable));
+
+                    if (false === method_exists($indexInstance, $method)) {
+                        throw new InvalidSettingName(sprintf('Invalid setting name: "%s"', $variable));
+                    }
+
+                    $update = $indexInstance->{$method}($value);
+
+                    $indexInstance->waitForPendingUpdate($update['updateId']);
+                    $updateStatus = $indexInstance->getUpdateStatus($update['updateId']);
+
+                    if ('failed' === $updateStatus['status']) {
+                        throw new UpdateException($updateStatus['error']);
+                    }
+                }
+            }
+        }
+
+        $output->writeln('<info>Done!</info>');
+
+        return 0;
+    }
+}

--- a/tests/Integration/CommandsTest.php
+++ b/tests/Integration/CommandsTest.php
@@ -213,4 +213,42 @@ EOD, $clearOutput);
         $this->assertStringContainsString('Done!', $output);
         $this->assertSame(0, $return);
     }
+
+    public function testSearchCreateWithoutIndices(): void
+    {
+        $createCommand = $this->application->find('meili:create');
+        $createCommandTester = new CommandTester($createCommand);
+        $createCommandTester->execute([]);
+
+        $createOutput = $createCommandTester->getDisplay();
+
+        $this->assertSame(<<<'EOD'
+Creating index sf_phpunit__posts for MeiliSearch\Bundle\Test\Entity\Post
+Creating index sf_phpunit__comments for MeiliSearch\Bundle\Test\Entity\Comment
+Creating index sf_phpunit__tags for MeiliSearch\Bundle\Test\Entity\Tag
+Creating index sf_phpunit__tags for MeiliSearch\Bundle\Test\Entity\Link
+Creating index sf_phpunit__pages for MeiliSearch\Bundle\Test\Entity\Page
+Creating index sf_phpunit__aggregated for MeiliSearch\Bundle\Test\Entity\Post
+Creating index sf_phpunit__aggregated for MeiliSearch\Bundle\Test\Entity\Tag
+Done!
+
+EOD, $createOutput);
+    }
+
+    public function testSearchCreateWithIndices(): void
+    {
+        $createCommand = $this->application->find('meili:create');
+        $createCommandTester = new CommandTester($createCommand);
+        $createCommandTester->execute([
+            '--indices' => 'posts',
+        ]);
+
+        $createOutput = $createCommandTester->getDisplay();
+
+        $this->assertSame(<<<'EOD'
+Creating index sf_phpunit__posts for MeiliSearch\Bundle\Test\Entity\Post
+Done!
+
+EOD, $createOutput);
+    }
 }


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Allows to create configured indexes without importing documents.
Sometimes it's convenient to create only indexes without importing before to test if app flow just works in case you have many entities and the device is slow to import documents.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
