### PR TITLE
Update MeiliSearchBundle.php for the next release (v0.7.0)

### DIFF
--- a/src/MeiliSearchBundle.php
+++ b/src/MeiliSearchBundle.php
@@ -11,5 +11,5 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class MeiliSearchBundle extends Bundle
 {
-    public const VERSION = '0.6.0';
+    public const VERSION = '0.7.0';
 }


### PR DESCRIPTION
Breaking because of https://github.com/meilisearch/meilisearch-symfony/pull/137
This PR updates meilisearch-php to v0.21.0 that only works with MeiliSearch v0.25.0 and later -> it enforces the users to upgrade their MeiliSearch version