### PR TITLE
Fix deprecation

### DIFF
--- a/src/Command/MeiliSearchImportCommand.php
+++ b/src/Command/MeiliSearchImportCommand.php
@@ -76,7 +76,7 @@ final class MeiliSearchImportCommand extends IndexCommand
 
         $entitiesToIndex = array_unique($indexes->toArray(), SORT_REGULAR);
         $batchSize = $input->getOption('batch-size');
-        $batchSize = ctype_digit($batchSize) ? (int) $batchSize : $config->get('batchSize');
+        $batchSize = null !== $batchSize && ctype_digit($batchSize) ? (int) $batchSize : $config->get('batchSize');
         $responseTimeout = ((int) $input->getOption('response-timeout')) ?: self::DEFAULT_RESPONSE_TIMEOUT;
 
         /** @var array $index */


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes PHP deprecation

When running import command without defining batch size PHP warns about:

```
PHP Deprecated: ctype_digit(): Argument of type null will be interpreted as string in the future in /vendor/meilisearch/search-bundle/src/Command/MeiliSearchImportCommand.php on line 79
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
