### PR TITLE
Update version for the next release (v0.7.2)

### DIFF
--- a/src/MeiliSearchBundle.php
+++ b/src/MeiliSearchBundle.php
@@ -11,5 +11,5 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class MeiliSearchBundle extends Bundle
 {
-    public const VERSION = '0.7.1';
+    public const VERSION = '0.7.2';
 }


### PR DESCRIPTION
Release notes:

This package version is compatible with [Meilisearch v0.26.0](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.26.0) 🎉 

## 🚀 Enhancements

* Updated `meilisearch-php` to v0.23 (#172) @dependabot
  * ⚠️ Check the [release notes](https://github.com/meilisearch/meilisearch-php/releases/tag/v0.23.0) from `meilisearch-php` for more information.
