### PR TITLE
Add landing_getting_started_1 code samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -1,0 +1,39 @@
+landing_getting_started_1: |-
+    # Configure your entities by adding them in config/packages/meili_search.yaml
+    meili_search:
+        url: 'http://127.0.0.1:7700'
+        api_key: 'masterKey'
+        indices:
+            - name: movies
+              class: App\Entity\Movie
+
+    <?php
+    // src/Controller/MoviesController.php
+    namespace App\Controller;
+
+    use App\Entity\Movie;
+    use Doctrine\Persistence\ManagerRegistry;
+    use Symfony\Component\HttpFoundation\Response;
+
+    class MoviesController extends AbstractController
+    {
+        #[Route('/add-movies', name: 'addMovies')]
+        public function addMovies(ManagerRegistry $doctrine): Response
+        {
+            $entityManager = $doctrine->getManager();
+
+            $movies = ['Carol', 'Wonder Woman', 'Life of Pi', 'Mad Max: Fury Road', 'Moana', 'Philadelphia'];
+
+            foreach ($movies as $title) {
+                $movie = new Movie();
+                $movie->setTitle($title);
+
+                $entityManager->persist($movie);
+            }
+
+            // Inserting data in your DB table will automatically update your Meilisearch index
+            $entityManager->flush();
+
+            //...
+        }
+    }

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -1,4 +1,5 @@
 landing_getting_started_1: |-
+    ```yml
     # Configure your entities by adding them in config/packages/meili_search.yaml
     meili_search:
         url: 'http://127.0.0.1:7700'
@@ -6,7 +7,9 @@ landing_getting_started_1: |-
         indices:
             - name: movies
               class: App\Entity\Movie
+    ```
 
+    ```php
     <?php
     // src/Controller/MoviesController.php
     namespace App\Controller;
@@ -37,3 +40,4 @@ landing_getting_started_1: |-
             //...
         }
     }
+    ```


### PR DESCRIPTION
Add a `landing_getting_started_1` code sample to be on the new landing page block.

Closes: https://github.com/meilisearch/meilisearch-symfony/issues/174