### PR TITLE
Update version for the next release (v0.8.0)

### DIFF
--- a/src/MeiliSearchBundle.php
+++ b/src/MeiliSearchBundle.php
@@ -11,5 +11,5 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class MeiliSearchBundle extends Bundle
 {
-    public const VERSION = '0.7.2';
+    public const VERSION = '0.8.0';
 }


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.28.0 :tada:
Check out the changelog of [Meilisearch v0.28.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0) for more information on the changes.

## 💥 Breaking changes

- This release is **only** compatible with the latest version of [Meilisearch v0.28.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0)

## 🚀 Enhancements

* Support Symfony 6.1 (#181) @norkunas
* Improve Docker configuration in the package (#182) @brunoocasali
* Fixed `ClassMetadata` usage in `SearchableEntity`. (#185) @althaus

## 🐛 Bug Fixes

* Fix meili:create when the configuration has no settings (#189) @brunoocasali

Thanks again to @althaus, @brunoocasali, and @norkunas! 🎉
