### PR TITLE
Rename MEILISEARCH_URL into  MEILISEARCH_HOST on docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     stdin_open: true
     working_dir: /home/package
     environment:
-      - MEILISEARCH_URL=http://meilisearch:7700
+      - MEILISEARCH_HOST=http://meilisearch:7700
     depends_on:
       - meilisearch
     links:


### PR DESCRIPTION
Fixing missed spot on #200 