### PR TITLE
feat(settings): add support for `typoTolerance`

### DIFF
--- a/tests/Integration/CommandsTest.php
+++ b/tests/Integration/CommandsTest.php
@@ -77,6 +77,7 @@ Indexed 6 / 6 MeiliSearch\Bundle\Test\Entity\Post entities into sf_phpunit__post
 Indexed 6 / 6 MeiliSearch\Bundle\Test\Entity\Post entities into sf_phpunit__aggregated index
 Settings updated.
 Settings updated.
+Settings updated.
 Importing for index MeiliSearch\Bundle\Test\Entity\Comment
 Importing for index MeiliSearch\Bundle\Test\Entity\Tag
 Indexed 6 / 6 MeiliSearch\Bundle\Test\Entity\Tag entities into sf_phpunit__tags index

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -6,6 +6,7 @@ namespace MeiliSearch\Bundle\Test\Integration;
 
 use MeiliSearch\Bundle\Test\BaseKernelTestCase;
 use MeiliSearch\Client;
+use MeiliSearch\Contracts\Index\TypoTolerance;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -60,5 +61,12 @@ class SettingsTest extends BaseKernelTestCase
 
         $this->assertNotEmpty($settings['filterableAttributes']);
         $this->assertEquals(['publishedAt', 'title'], $settings['filterableAttributes']);
+
+        $this->assertArrayHasKey('typoTolerance', $settings);
+        $this->assertInstanceOf(TypoTolerance::class, $settings['typoTolerance']);
+        $this->assertTrue($settings['typoTolerance']['enabled']);
+        $this->assertEquals(['title'], $settings['typoTolerance']['disableOnAttributes']);
+        $this->assertEquals(['york'], $settings['typoTolerance']['disableOnWords']);
+        $this->assertEquals(['oneTypo' => 5, 'twoTypos' => 9], $settings['typoTolerance']['minWordSizeForTypos']);
     }
 }

--- a/tests/config/meili_search.yaml
+++ b/tests/config/meili_search.yaml
@@ -11,6 +11,13 @@ meili_search:
             settings:
                 stopWords: ['the', 'a', 'an']
                 filterableAttributes: ['title', 'publishedAt']
+                typoTolerance:
+                    enabled: true
+                    disableOnAttributes: ['title']
+                    disableOnWords: ['york']
+                    minWordSizeForTypos:
+                        oneTypo: 5
+                        twoTypos: 9
         -   name: comments
             class: 'MeiliSearch\Bundle\Test\Entity\Comment'
         -   name: aggregated


### PR DESCRIPTION
This change adds the ability to specify the `typoTolerance` as described in https://github.com/meilisearch/specifications/pull/117

# Pull Request

## Related issue
Fixes #179

## What does this PR do?
- This change adds the ability to specify `typoTolerance` for a given index.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
