### PR TITLE
Update version for the next release (v0.9.0)

### DIFF
--- a/src/MeiliSearchBundle.php
+++ b/src/MeiliSearchBundle.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class MeiliSearchBundle extends Bundle
 {
-    public const VERSION = '0.8.2';
+    public const VERSION = '0.9.0';
 
     public static function qualifiedVersion()
     {


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.30.0 :tada:
Check out the changelog of [Meilisearch v0.30.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0) for more information on the changes.

## ⚠️ Breaking changes

This release is **only** compatible with the latest version of [Meilisearch v0.30.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0) and greater

Thanks again to @brunoocasali 🎉