### PR TITLE
Move every occurrence of MeiliSearch to Meilisearch

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -1,7 +1,7 @@
 landing_getting_started_1: |-
     ```yml
-    # Configure your entities by adding them in config/packages/meili_search.yaml
-    meili_search:
+    # Configure your entities by adding them in config/packages/meilisearch.yaml
+    meilisearch:
         url: 'http://127.0.0.1:7700'
         api_key: 'masterKey'
         indices:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ _[Read more about this](https://github.com/meilisearch/integration-guides/blob/m
 
 ⚠️ Before doing anything, make sure you got through the guide about [Releasing an Integration](https://github.com/meilisearch/integration-guides/blob/main/resources/integration-release.md).
 
-Make a PR modifying the file [`src/MeiliSearchBundle.php`](/src/MeiliSearchBundle.php) with the right version.
+Make a PR modifying the file [`src/MeilisearchBundle.php`](/src/MeilisearchBundle.php) with the right version.
 
 ```php
 VERSION = 'X.X.X'

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "php": "^7.4|^8.0",
     "ext-json": "*",
     "doctrine/doctrine-bundle": "^2.4",
-    "meilisearch/meilisearch-php": "^0.26.0",
+    "meilisearch/meilisearch-php": "^0.26.1",
     "symfony/filesystem": "^4.4 || ^5.0 || ^6.0",
     "symfony/property-access": "^4.4 || ^5.0 || ^6.0",
     "symfony/serializer": "^4.4 || ^5.0 || ^6.0"
@@ -45,12 +45,12 @@
   },
   "autoload": {
     "psr-4": {
-      "MeiliSearch\\Bundle\\": "src/"
+      "Meilisearch\\Bundle\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "MeiliSearch\\Bundle\\Test\\": "tests/"
+      "Meilisearch\\Bundle\\Test\\": "tests/"
     }
   },
   "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
         </include>
     </coverage>
     <php>
-        <env name="KERNEL_CLASS" value="MeiliSearch\Bundle\Test\Kernel"/>
+        <env name="KERNEL_CLASS" value="Meilisearch\Bundle\Test\Kernel"/>
         <env name="APP_ENV" value="test"/>
         <env name="APP_DEBUG" value="false"/>
         <env name="MEILISEARCH_PREFIX" value="sf_phpunit_"/>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle;
+namespace Meilisearch\Bundle;
 
 final class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
 {

--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Command;
+namespace Meilisearch\Bundle\Command;
 
-use MeiliSearch\Bundle\Collection;
-use MeiliSearch\Bundle\SearchService;
+use Meilisearch\Bundle\Collection;
+use Meilisearch\Bundle\SearchService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Command/MeiliSearchCreateCommand.php
+++ b/src/Command/MeiliSearchCreateCommand.php
@@ -9,7 +9,7 @@ use MeiliSearch\Bundle\Exception\InvalidSettingName;
 use MeiliSearch\Bundle\Exception\TaskException;
 use MeiliSearch\Bundle\Model\Aggregator;
 use MeiliSearch\Bundle\SearchService;
-use MeiliSearch\Client;
+use Meilisearch\Client;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Command/MeiliSearchDeleteCommand.php
+++ b/src/Command/MeiliSearchDeleteCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MeiliSearch\Bundle\Command;
 
 use MeiliSearch\Bundle\Collection;
-use MeiliSearch\Exceptions\ApiException;
+use Meilisearch\Exceptions\ApiException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Command/MeiliSearchImportCommand.php
+++ b/src/Command/MeiliSearchImportCommand.php
@@ -10,7 +10,7 @@ use MeiliSearch\Bundle\Exception\InvalidSettingName;
 use MeiliSearch\Bundle\Exception\TaskException;
 use MeiliSearch\Bundle\Model\Aggregator;
 use MeiliSearch\Bundle\SearchService;
-use MeiliSearch\Client;
+use Meilisearch\Client;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Command/MeilisearchClearCommand.php
+++ b/src/Command/MeilisearchClearCommand.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Command;
+namespace Meilisearch\Bundle\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class MeiliSearchClearCommand.
+ * Class MeilisearchClearCommand.
  */
-final class MeiliSearchClearCommand extends IndexCommand
+final class MeilisearchClearCommand extends IndexCommand
 {
     public static function getDefaultName(): string
     {

--- a/src/Command/MeilisearchCreateCommand.php
+++ b/src/Command/MeilisearchCreateCommand.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Command;
+namespace Meilisearch\Bundle\Command;
 
-use MeiliSearch\Bundle\Collection;
-use MeiliSearch\Bundle\Exception\InvalidSettingName;
-use MeiliSearch\Bundle\Exception\TaskException;
-use MeiliSearch\Bundle\Model\Aggregator;
-use MeiliSearch\Bundle\SearchService;
+use Meilisearch\Bundle\Collection;
+use Meilisearch\Bundle\Exception\InvalidSettingName;
+use Meilisearch\Bundle\Exception\TaskException;
+use Meilisearch\Bundle\Model\Aggregator;
+use Meilisearch\Bundle\SearchService;
 use Meilisearch\Client;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class MeiliSearchCreateCommand extends IndexCommand
+final class MeilisearchCreateCommand extends IndexCommand
 {
     private Client $searchClient;
 

--- a/src/Command/MeilisearchDeleteCommand.php
+++ b/src/Command/MeilisearchDeleteCommand.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Command;
+namespace Meilisearch\Bundle\Command;
 
-use MeiliSearch\Bundle\Collection;
+use Meilisearch\Bundle\Collection;
 use Meilisearch\Exceptions\ApiException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class MeiliSearchDeleteCommand.
+ * Class MeilisearchDeleteCommand.
  */
-final class MeiliSearchDeleteCommand extends IndexCommand
+final class MeilisearchDeleteCommand extends IndexCommand
 {
     public static function getDefaultName(): string
     {

--- a/src/Command/MeilisearchImportCommand.php
+++ b/src/Command/MeilisearchImportCommand.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Command;
+namespace Meilisearch\Bundle\Command;
 
 use Doctrine\Persistence\ManagerRegistry;
-use MeiliSearch\Bundle\Collection;
-use MeiliSearch\Bundle\Exception\InvalidSettingName;
-use MeiliSearch\Bundle\Exception\TaskException;
-use MeiliSearch\Bundle\Model\Aggregator;
-use MeiliSearch\Bundle\SearchService;
+use Meilisearch\Bundle\Collection;
+use Meilisearch\Bundle\Exception\InvalidSettingName;
+use Meilisearch\Bundle\Exception\TaskException;
+use Meilisearch\Bundle\Model\Aggregator;
+use Meilisearch\Bundle\SearchService;
 use Meilisearch\Client;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class MeiliSearchImportCommand.
+ * Class MeilisearchImportCommand.
  */
-final class MeiliSearchImportCommand extends IndexCommand
+final class MeilisearchImportCommand extends IndexCommand
 {
     private const DEFAULT_RESPONSE_TIMEOUT = 5000;
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\DependencyInjection;
+namespace Meilisearch\Bundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;

--- a/src/DependencyInjection/MeilisearchExtension.php
+++ b/src/DependencyInjection/MeilisearchExtension.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\DependencyInjection;
+namespace Meilisearch\Bundle\DependencyInjection;
 
-use MeiliSearch\Bundle\Engine;
-use MeiliSearch\Bundle\MeiliSearchBundle;
-use MeiliSearch\Bundle\Services\MeiliSearchService;
+use Meilisearch\Bundle\Engine;
+use Meilisearch\Bundle\MeilisearchBundle;
+use Meilisearch\Bundle\Services\MeilisearchService;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -15,9 +15,9 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * Class MeiliSearchExtension.
+ * Class MeilisearchExtension.
  */
-final class MeiliSearchExtension extends Extension
+final class MeilisearchExtension extends Extension
 {
     /**
      * {@inheritdoc}
@@ -36,7 +36,7 @@ final class MeiliSearchExtension extends Extension
 
         $container->setParameter('meili_url', $config['url'] ?? null);
         $container->setParameter('meili_api_key', $config['api_key'] ?? null);
-        $container->setParameter('meili_symfony_version', MeiliSearchBundle::qualifiedVersion());
+        $container->setParameter('meili_symfony_version', MeilisearchBundle::qualifiedVersion());
 
         if (\count($doctrineSubscribedEvents = $config['doctrineSubscribedEvents']) > 0) {
             $container->getDefinition('search.search_indexer_subscriber')->setArgument(1, $doctrineSubscribedEvents);
@@ -47,7 +47,7 @@ final class MeiliSearchExtension extends Extension
         $engineDefinition = new Definition(Engine::class, [new Reference('search.client')]);
 
         $searchServiceDefinition = (new Definition(
-            MeiliSearchService::class,
+            MeilisearchService::class,
             [new Reference($config['serializer']), $engineDefinition, $config]
         ));
 

--- a/src/Document/Aggregator.php
+++ b/src/Document/Aggregator.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Document;
+namespace Meilisearch\Bundle\Document;
 
-use MeiliSearch\Bundle\Model\Aggregator as BaseAggregator;
+use Meilisearch\Bundle\Model\Aggregator as BaseAggregator;
 
 /**
  * Class Aggregator.

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle;
+namespace Meilisearch\Bundle;
 
 use Meilisearch\Client;
 use Meilisearch\Exceptions\ApiException;

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Bundle;
 
-use MeiliSearch\Client;
-use MeiliSearch\Exceptions\ApiException;
+use Meilisearch\Client;
+use Meilisearch\Exceptions\ApiException;
 
 /**
  * Class Engine.

--- a/src/Entity/Aggregator.php
+++ b/src/Entity/Aggregator.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Entity;
+namespace Meilisearch\Bundle\Entity;
 
-use MeiliSearch\Bundle\Model\Aggregator as BaseAggregator;
+use Meilisearch\Bundle\Model\Aggregator as BaseAggregator;
 
 /**
  * Class Aggregator.

--- a/src/EventListener/DoctrineEventSubscriber.php
+++ b/src/EventListener/DoctrineEventSubscriber.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\EventListener;
+namespace Meilisearch\Bundle\EventListener;
 
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
-use MeiliSearch\Bundle\SearchService;
+use Meilisearch\Bundle\SearchService;
 
 final class DoctrineEventSubscriber implements EventSubscriber
 {

--- a/src/Exception/EntityNotFoundInObjectID.php
+++ b/src/Exception/EntityNotFoundInObjectID.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Exception;
+namespace Meilisearch\Bundle\Exception;
 
 /**
  * Class EntityNotFoundInObjectID.

--- a/src/Exception/InvalidEntityForAggregator.php
+++ b/src/Exception/InvalidEntityForAggregator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Exception;
+namespace Meilisearch\Bundle\Exception;
 
 final class InvalidEntityForAggregator extends \LogicException
 {

--- a/src/Exception/InvalidSettingName.php
+++ b/src/Exception/InvalidSettingName.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Exception;
+namespace Meilisearch\Bundle\Exception;
 
 /**
  * Class InvalidSettingName.

--- a/src/Exception/ObjectIdNotFoundException.php
+++ b/src/Exception/ObjectIdNotFoundException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Exception;
+namespace Meilisearch\Bundle\Exception;
 
 /**
  * Class ObjectIdNotFoundException.

--- a/src/Exception/SearchHitsNotFoundException.php
+++ b/src/Exception/SearchHitsNotFoundException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Exception;
+namespace Meilisearch\Bundle\Exception;
 
 /**
  * Class SearchHitsNotFoundException.

--- a/src/Exception/TaskException.php
+++ b/src/Exception/TaskException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Exception;
+namespace Meilisearch\Bundle\Exception;
 
 /**
  * Class TaskException.

--- a/src/MeilisearchBundle.php
+++ b/src/MeilisearchBundle.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle;
+namespace Meilisearch\Bundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Class MeiliSearchBundle.
+ * Class MeilisearchBundle.
  */
-final class MeiliSearchBundle extends Bundle
+final class MeilisearchBundle extends Bundle
 {
     public const VERSION = '0.9.0';
 
     public static function qualifiedVersion()
     {
-        return sprintf('Meilisearch Symfony (v%s)', MeiliSearchBundle::VERSION);
+        return sprintf('Meilisearch Symfony (v%s)', MeilisearchBundle::VERSION);
     }
 }

--- a/src/Model/Aggregator.php
+++ b/src/Model/Aggregator.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Model;
+namespace Meilisearch\Bundle\Model;
 
-use MeiliSearch\Bundle\Exception\EntityNotFoundInObjectID;
-use MeiliSearch\Bundle\Exception\InvalidEntityForAggregator;
+use Meilisearch\Bundle\Exception\EntityNotFoundInObjectID;
+use Meilisearch\Bundle\Exception\InvalidEntityForAggregator;
 use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 

--- a/src/Resources/config/doctrine/Aggregator.mongodb.xml
+++ b/src/Resources/config/doctrine/Aggregator.mongodb.xml
@@ -4,7 +4,7 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <mapped-superclass name="MeiliSearch\Bundle\Document\Aggregator">
+    <mapped-superclass name="Meilisearch\Bundle\Document\Aggregator">
         <id field-name="objectID"/>
     </mapped-superclass>
 

--- a/src/Resources/config/doctrine/Aggregator.orm.xml
+++ b/src/Resources/config/doctrine/Aggregator.orm.xml
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                   http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <mapped-superclass name="MeiliSearch\Bundle\Entity\Aggregator">
+    <mapped-superclass name="Meilisearch\Bundle\Entity\Aggregator">
         <id name="objectID" type="string">
             <generator strategy="AUTO"/>
         </id>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -6,10 +6,10 @@
     <services>
         <defaults autowire="true" autoconfigure="true"/>
 
-        <prototype namespace="MeiliSearch\Bundle\Command\" resource="../../Command" />
+        <prototype namespace="Meilisearch\Bundle\Command\" resource="../../Command" />
 
         <service id="search.search_indexer_subscriber"
-                 class="MeiliSearch\Bundle\EventListener\DoctrineEventSubscriber"
+                 class="Meilisearch\Bundle\EventListener\DoctrineEventSubscriber"
                  public="true">
             <argument type="service" id="search.service"/>
             <argument type="collection"/> <!-- doctrine subscribed events -->
@@ -27,6 +27,6 @@
         </service>
 
         <service id="Meilisearch\Client" alias="search.client"/>
-        <service id="MeiliSearch\Bundle\SearchService" alias="search.service"/>
+        <service id="Meilisearch\Bundle\SearchService" alias="search.service"/>
     </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -17,7 +17,7 @@
             <tag name="doctrine_mongodb.odm.event_subscriber"/>
         </service>
 
-        <service id="search.client" class="MeiliSearch\Client" public="true" lazy="true">
+        <service id="search.client" class="Meilisearch\Client" public="true" lazy="true">
             <argument key="$url">%meili_url%</argument>
             <argument key="$apiKey">%meili_api_key%</argument>
             <argument key="$httpClient" type="service" id="psr18.http_client" on-invalid="ignore" />
@@ -26,7 +26,7 @@
             </argument>
         </service>
 
-        <service id="MeiliSearch\Client" alias="search.client"/>
+        <service id="Meilisearch\Client" alias="search.client"/>
         <service id="MeiliSearch\Bundle\SearchService" alias="search.service"/>
     </services>
 </container>

--- a/src/SearchService.php
+++ b/src/SearchService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle;
+namespace Meilisearch\Bundle;
 
 use Doctrine\Persistence\ObjectManager;
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle;
+namespace Meilisearch\Bundle;
 
 /**
  * Class Searchable.

--- a/src/SearchableEntity.php
+++ b/src/SearchableEntity.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle;
+namespace Meilisearch\Bundle;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Symfony\Component\Config\Definition\Exception\Exception;

--- a/src/Services/MeilisearchService.php
+++ b/src/Services/MeilisearchService.php
@@ -2,26 +2,26 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Services;
+namespace Meilisearch\Bundle\Services;
 
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\ObjectManager;
-use MeiliSearch\Bundle\Collection;
-use MeiliSearch\Bundle\Engine;
-use MeiliSearch\Bundle\Entity\Aggregator;
-use MeiliSearch\Bundle\Exception\ObjectIdNotFoundException;
-use MeiliSearch\Bundle\Exception\SearchHitsNotFoundException;
-use MeiliSearch\Bundle\SearchableEntity;
-use MeiliSearch\Bundle\SearchService;
+use Meilisearch\Bundle\Collection;
+use Meilisearch\Bundle\Engine;
+use Meilisearch\Bundle\Entity\Aggregator;
+use Meilisearch\Bundle\Exception\ObjectIdNotFoundException;
+use Meilisearch\Bundle\Exception\SearchHitsNotFoundException;
+use Meilisearch\Bundle\SearchableEntity;
+use Meilisearch\Bundle\SearchService;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
- * Class MeiliSearchService.
+ * Class MeilisearchService.
  */
-final class MeiliSearchService implements SearchService
+final class MeilisearchService implements SearchService
 {
     private SerializerInterface $normalizer;
     private Engine $engine;

--- a/tests/BaseKernelTestCase.php
+++ b/tests/BaseKernelTestCase.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test;
+namespace Meilisearch\Bundle\Test;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
-use MeiliSearch\Bundle\Collection;
-use MeiliSearch\Bundle\SearchableEntity;
-use MeiliSearch\Bundle\SearchService;
-use MeiliSearch\Bundle\Test\Entity\Comment;
-use MeiliSearch\Bundle\Test\Entity\Image;
-use MeiliSearch\Bundle\Test\Entity\Link;
-use MeiliSearch\Bundle\Test\Entity\ObjectId\DummyObjectId;
-use MeiliSearch\Bundle\Test\Entity\Page;
-use MeiliSearch\Bundle\Test\Entity\Post;
-use MeiliSearch\Bundle\Test\Entity\Tag;
-use MeiliSearch\Exceptions\ApiException;
+use Meilisearch\Bundle\Collection;
+use Meilisearch\Bundle\SearchableEntity;
+use Meilisearch\Bundle\SearchService;
+use Meilisearch\Bundle\Test\Entity\Comment;
+use Meilisearch\Bundle\Test\Entity\Image;
+use Meilisearch\Bundle\Test\Entity\Link;
+use Meilisearch\Bundle\Test\Entity\ObjectId\DummyObjectId;
+use Meilisearch\Bundle\Test\Entity\Page;
+use Meilisearch\Bundle\Test\Entity\Post;
+use Meilisearch\Bundle\Test\Entity\Tag;
+use Meilisearch\Exceptions\ApiException;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 abstract class BaseKernelTestCase extends KernelTestCase

--- a/tests/Entity/Comment.php
+++ b/tests/Entity/Comment.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Entity;
+namespace Meilisearch\Bundle\Test\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;

--- a/tests/Entity/ContentAggregator.php
+++ b/tests/Entity/ContentAggregator.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Entity;
+namespace Meilisearch\Bundle\Test\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use MeiliSearch\Bundle\Entity\Aggregator;
+use Meilisearch\Bundle\Entity\Aggregator;
 
 /**
  * @ORM\Entity

--- a/tests/Entity/EmptyAggregator.php
+++ b/tests/Entity/EmptyAggregator.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Entity;
+namespace Meilisearch\Bundle\Test\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use MeiliSearch\Bundle\Entity\Aggregator;
+use Meilisearch\Bundle\Entity\Aggregator;
 
 /**
  * @ORM\Entity

--- a/tests/Entity/Image.php
+++ b/tests/Entity/Image.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Entity;
+namespace Meilisearch\Bundle\Test\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 

--- a/tests/Entity/Link.php
+++ b/tests/Entity/Link.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Entity;
+namespace Meilisearch\Bundle\Test\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use MeiliSearch\Bundle\Searchable;
+use Meilisearch\Bundle\Searchable;
 use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 

--- a/tests/Entity/ObjectId/DummyObjectId.php
+++ b/tests/Entity/ObjectId/DummyObjectId.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Entity\ObjectId;
+namespace Meilisearch\Bundle\Test\Entity\ObjectId;
 
 class DummyObjectId
 {

--- a/tests/Entity/Page.php
+++ b/tests/Entity/Page.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Entity;
+namespace Meilisearch\Bundle\Test\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;

--- a/tests/Entity/Post.php
+++ b/tests/Entity/Post.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Entity;
+namespace Meilisearch\Bundle\Test\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;

--- a/tests/Entity/Tag.php
+++ b/tests/Entity/Tag.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Entity;
+namespace Meilisearch\Bundle\Test\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use MeiliSearch\Bundle\Searchable;
+use Meilisearch\Bundle\Searchable;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;

--- a/tests/Integration/AggregatorTest.php
+++ b/tests/Integration/AggregatorTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Integration;
+namespace Meilisearch\Bundle\Test\Integration;
 
-use MeiliSearch\Bundle\Exception\EntityNotFoundInObjectID;
-use MeiliSearch\Bundle\Exception\InvalidEntityForAggregator;
-use MeiliSearch\Bundle\Test\BaseKernelTestCase;
-use MeiliSearch\Bundle\Test\Entity\ContentAggregator;
-use MeiliSearch\Bundle\Test\Entity\EmptyAggregator;
-use MeiliSearch\Bundle\Test\Entity\Post;
+use Meilisearch\Bundle\Exception\EntityNotFoundInObjectID;
+use Meilisearch\Bundle\Exception\InvalidEntityForAggregator;
+use Meilisearch\Bundle\Test\BaseKernelTestCase;
+use Meilisearch\Bundle\Test\Entity\ContentAggregator;
+use Meilisearch\Bundle\Test\Entity\EmptyAggregator;
+use Meilisearch\Bundle\Test\Entity\Post;
 use Symfony\Component\Serializer\Serializer;
 
 class AggregatorTest extends BaseKernelTestCase

--- a/tests/Integration/CommandsTest.php
+++ b/tests/Integration/CommandsTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Integration;
+namespace Meilisearch\Bundle\Test\Integration;
 
-use MeiliSearch\Bundle\Test\BaseKernelTestCase;
-use MeiliSearch\Client;
-use MeiliSearch\Endpoints\Indexes;
-use MeiliSearch\Exceptions\ApiException;
-use MeiliSearch\Search\SearchResult;
+use Meilisearch\Bundle\Test\BaseKernelTestCase;
+use Meilisearch\Client;
+use Meilisearch\Endpoints\Indexes;
+use Meilisearch\Exceptions\ApiException;
+use Meilisearch\Search\SearchResult;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -72,25 +72,25 @@ class CommandsTest extends BaseKernelTestCase
         $importOutput = $importCommandTester->getDisplay();
 
         $this->assertSame(<<<'EOD'
-Importing for index MeiliSearch\Bundle\Test\Entity\Post
-Indexed 6 / 6 MeiliSearch\Bundle\Test\Entity\Post entities into sf_phpunit__posts index
-Indexed 6 / 6 MeiliSearch\Bundle\Test\Entity\Post entities into sf_phpunit__aggregated index
+Importing for index Meilisearch\Bundle\Test\Entity\Post
+Indexed 6 / 6 Meilisearch\Bundle\Test\Entity\Post entities into sf_phpunit__posts index
+Indexed 6 / 6 Meilisearch\Bundle\Test\Entity\Post entities into sf_phpunit__aggregated index
 Settings updated.
 Settings updated.
 Settings updated.
-Importing for index MeiliSearch\Bundle\Test\Entity\Comment
-Importing for index MeiliSearch\Bundle\Test\Entity\Tag
-Indexed 6 / 6 MeiliSearch\Bundle\Test\Entity\Tag entities into sf_phpunit__tags index
-Indexed 6 / 6 MeiliSearch\Bundle\Test\Entity\Tag entities into sf_phpunit__aggregated index
-Importing for index MeiliSearch\Bundle\Test\Entity\Link
-Importing for index MeiliSearch\Bundle\Test\Entity\Page
-Indexed 6 / 6 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
-Importing for index MeiliSearch\Bundle\Test\Entity\Post
-Indexed 6 / 6 MeiliSearch\Bundle\Test\Entity\Post entities into sf_phpunit__posts index
-Indexed 6 / 6 MeiliSearch\Bundle\Test\Entity\Post entities into sf_phpunit__aggregated index
-Importing for index MeiliSearch\Bundle\Test\Entity\Tag
-Indexed 6 / 6 MeiliSearch\Bundle\Test\Entity\Tag entities into sf_phpunit__tags index
-Indexed 6 / 6 MeiliSearch\Bundle\Test\Entity\Tag entities into sf_phpunit__aggregated index
+Importing for index Meilisearch\Bundle\Test\Entity\Comment
+Importing for index Meilisearch\Bundle\Test\Entity\Tag
+Indexed 6 / 6 Meilisearch\Bundle\Test\Entity\Tag entities into sf_phpunit__tags index
+Indexed 6 / 6 Meilisearch\Bundle\Test\Entity\Tag entities into sf_phpunit__aggregated index
+Importing for index Meilisearch\Bundle\Test\Entity\Link
+Importing for index Meilisearch\Bundle\Test\Entity\Page
+Indexed 6 / 6 Meilisearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Importing for index Meilisearch\Bundle\Test\Entity\Post
+Indexed 6 / 6 Meilisearch\Bundle\Test\Entity\Post entities into sf_phpunit__posts index
+Indexed 6 / 6 Meilisearch\Bundle\Test\Entity\Post entities into sf_phpunit__aggregated index
+Importing for index Meilisearch\Bundle\Test\Entity\Tag
+Indexed 6 / 6 Meilisearch\Bundle\Test\Entity\Tag entities into sf_phpunit__tags index
+Indexed 6 / 6 Meilisearch\Bundle\Test\Entity\Tag entities into sf_phpunit__aggregated index
 Done!
 
 EOD, $importOutput);
@@ -102,12 +102,12 @@ EOD, $importOutput);
         $clearOutput = $clearCommandTester->getDisplay();
 
         $this->assertSame(<<<'EOD'
-Cleared sf_phpunit__posts index of MeiliSearch\Bundle\Test\Entity\Post
-Cleared sf_phpunit__comments index of MeiliSearch\Bundle\Test\Entity\Comment
-Cleared sf_phpunit__aggregated index of MeiliSearch\Bundle\Test\Entity\ContentAggregator
-Cleared sf_phpunit__tags index of MeiliSearch\Bundle\Test\Entity\Tag
-Cleared sf_phpunit__tags index of MeiliSearch\Bundle\Test\Entity\Link
-Cleared sf_phpunit__pages index of MeiliSearch\Bundle\Test\Entity\Page
+Cleared sf_phpunit__posts index of Meilisearch\Bundle\Test\Entity\Post
+Cleared sf_phpunit__comments index of Meilisearch\Bundle\Test\Entity\Comment
+Cleared sf_phpunit__aggregated index of Meilisearch\Bundle\Test\Entity\ContentAggregator
+Cleared sf_phpunit__tags index of Meilisearch\Bundle\Test\Entity\Tag
+Cleared sf_phpunit__tags index of Meilisearch\Bundle\Test\Entity\Link
+Cleared sf_phpunit__pages index of Meilisearch\Bundle\Test\Entity\Page
 Done!
 
 EOD, $clearOutput);
@@ -145,13 +145,13 @@ EOD, $clearOutput);
         $importOutput = $importCommandTester->getDisplay();
 
         $this->assertSame(<<<'EOD'
-Importing for index MeiliSearch\Bundle\Test\Entity\Page
-Indexed 2 / 2 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
-Indexed 2 / 2 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
-Indexed 2 / 2 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
-Indexed 2 / 2 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
-Indexed 2 / 2 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
-Indexed 1 / 1 MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Importing for index Meilisearch\Bundle\Test\Entity\Page
+Indexed 2 / 2 Meilisearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Indexed 2 / 2 Meilisearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Indexed 2 / 2 Meilisearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Indexed 2 / 2 Meilisearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Indexed 2 / 2 Meilisearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
+Indexed 1 / 1 Meilisearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index
 Done!
 
 EOD, $importOutput);
@@ -171,8 +171,8 @@ EOD, $importOutput);
         ]);
         $output = $importCommandTester->getDisplay();
 
-        $this->assertStringContainsString('Importing for index MeiliSearch\Bundle\Test\Entity\Page', $output);
-        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index', $output);
+        $this->assertStringContainsString('Importing for index Meilisearch\Bundle\Test\Entity\Page', $output);
+        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' Meilisearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index', $output);
         $this->assertStringContainsString('Done!', $output);
         $this->assertSame(0, $return);
 
@@ -192,8 +192,8 @@ EOD, $importOutput);
         ]);
         $output = $importCommandTester->getDisplay();
 
-        $this->assertStringContainsString('Importing for index MeiliSearch\Bundle\Test\Entity\Page', $output);
-        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' MeiliSearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index', $output);
+        $this->assertStringContainsString('Importing for index Meilisearch\Bundle\Test\Entity\Page', $output);
+        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' Meilisearch\Bundle\Test\Entity\Page entities into sf_phpunit__pages index', $output);
         $this->assertStringContainsString('Done!', $output);
         $this->assertSame(0, $return);
     }
@@ -216,9 +216,9 @@ EOD, $importOutput);
         ]);
 
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('Importing for index MeiliSearch\Bundle\Test\Entity\Tag', $output);
-        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' MeiliSearch\Bundle\Test\Entity\Tag entities into sf_phpunit__tags index', $output);
-        $this->assertStringContainsString('Indexed 2 / 2 MeiliSearch\Bundle\Test\Entity\Link entities into sf_phpunit__tags index', $output);
+        $this->assertStringContainsString('Importing for index Meilisearch\Bundle\Test\Entity\Tag', $output);
+        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' Meilisearch\Bundle\Test\Entity\Tag entities into sf_phpunit__tags index', $output);
+        $this->assertStringContainsString('Indexed 2 / 2 Meilisearch\Bundle\Test\Entity\Link entities into sf_phpunit__tags index', $output);
         $this->assertStringContainsString('Done!', $output);
 
         /** @var SearchResult $searchResult */
@@ -240,8 +240,8 @@ EOD, $importOutput);
         ]);
 
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('Importing for index MeiliSearch\Bundle\Test\Entity\Post', $output);
-        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' MeiliSearch\Bundle\Test\Entity\Post entities into sf_phpunit__'.self::$indexName.' index', $output);
+        $this->assertStringContainsString('Importing for index Meilisearch\Bundle\Test\Entity\Post', $output);
+        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' Meilisearch\Bundle\Test\Entity\Post entities into sf_phpunit__'.self::$indexName.' index', $output);
         $this->assertStringContainsString('Done!', $output);
         $this->assertSame(0, $return);
     }
@@ -259,8 +259,8 @@ EOD, $importOutput);
         ]);
 
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('Importing for index MeiliSearch\Bundle\Test\Entity\Post', $output);
-        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' MeiliSearch\Bundle\Test\Entity\Post entities into sf_phpunit__'.self::$indexName.' index', $output);
+        $this->assertStringContainsString('Importing for index Meilisearch\Bundle\Test\Entity\Post', $output);
+        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' Meilisearch\Bundle\Test\Entity\Post entities into sf_phpunit__'.self::$indexName.' index', $output);
         $this->assertStringContainsString('Done!', $output);
         $this->assertSame(0, $return);
 
@@ -278,8 +278,8 @@ EOD, $importOutput);
         ]);
 
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('Importing for index MeiliSearch\Bundle\Test\Entity\Post', $output);
-        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' MeiliSearch\Bundle\Test\Entity\Post entities into sf_phpunit__'.self::$indexName.' index', $output);
+        $this->assertStringContainsString('Importing for index Meilisearch\Bundle\Test\Entity\Post', $output);
+        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' Meilisearch\Bundle\Test\Entity\Post entities into sf_phpunit__'.self::$indexName.' index', $output);
         $this->assertStringContainsString('Done!', $output);
         $this->assertSame(0, $return);
     }
@@ -293,13 +293,13 @@ EOD, $importOutput);
         $createOutput = $createCommandTester->getDisplay();
 
         $this->assertSame(<<<'EOD'
-Creating index sf_phpunit__posts for MeiliSearch\Bundle\Test\Entity\Post
-Creating index sf_phpunit__comments for MeiliSearch\Bundle\Test\Entity\Comment
-Creating index sf_phpunit__tags for MeiliSearch\Bundle\Test\Entity\Tag
-Creating index sf_phpunit__tags for MeiliSearch\Bundle\Test\Entity\Link
-Creating index sf_phpunit__pages for MeiliSearch\Bundle\Test\Entity\Page
-Creating index sf_phpunit__aggregated for MeiliSearch\Bundle\Test\Entity\Post
-Creating index sf_phpunit__aggregated for MeiliSearch\Bundle\Test\Entity\Tag
+Creating index sf_phpunit__posts for Meilisearch\Bundle\Test\Entity\Post
+Creating index sf_phpunit__comments for Meilisearch\Bundle\Test\Entity\Comment
+Creating index sf_phpunit__tags for Meilisearch\Bundle\Test\Entity\Tag
+Creating index sf_phpunit__tags for Meilisearch\Bundle\Test\Entity\Link
+Creating index sf_phpunit__pages for Meilisearch\Bundle\Test\Entity\Page
+Creating index sf_phpunit__aggregated for Meilisearch\Bundle\Test\Entity\Post
+Creating index sf_phpunit__aggregated for Meilisearch\Bundle\Test\Entity\Tag
 Done!
 
 EOD, $createOutput);
@@ -316,7 +316,7 @@ EOD, $createOutput);
         $createOutput = $createCommandTester->getDisplay();
 
         $this->assertSame(<<<'EOD'
-Creating index sf_phpunit__posts for MeiliSearch\Bundle\Test\Entity\Post
+Creating index sf_phpunit__posts for Meilisearch\Bundle\Test\Entity\Post
 Done!
 
 EOD, $createOutput);

--- a/tests/Integration/DependencyInjectionTest.php
+++ b/tests/Integration/DependencyInjectionTest.php
@@ -3,15 +3,15 @@
 declare(strict_types=1);
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
-use MeiliSearch\Bundle\DependencyInjection\MeiliSearchExtension;
-use MeiliSearch\Bundle\MeiliSearchBundle;
+use Meilisearch\Bundle\DependencyInjection\MeilisearchExtension;
+use Meilisearch\Bundle\MeilisearchBundle;
 
-class MeiliSearchExtensionTest extends AbstractExtensionTestCase
+class MeilisearchExtensionTest extends AbstractExtensionTestCase
 {
     protected function getContainerExtensions(): array
     {
         return [
-            new MeiliSearchExtension(),
+            new MeilisearchExtension(),
         ];
     }
 
@@ -26,6 +26,6 @@ class MeiliSearchExtensionTest extends AbstractExtensionTestCase
     {
         $this->load();
 
-        $this->assertContainerBuilderHasParameter('meili_symfony_version', MeiliSearchBundle::qualifiedVersion());
+        $this->assertContainerBuilderHasParameter('meili_symfony_version', MeilisearchBundle::qualifiedVersion());
     }
 }

--- a/tests/Integration/EngineTest.php
+++ b/tests/Integration/EngineTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Integration;
+namespace Meilisearch\Bundle\Test\Integration;
 
-use MeiliSearch\Bundle\Engine;
-use MeiliSearch\Bundle\Test\BaseKernelTestCase;
-use MeiliSearch\Exceptions\ApiException;
+use Meilisearch\Bundle\Engine;
+use Meilisearch\Bundle\Test\BaseKernelTestCase;
+use Meilisearch\Exceptions\ApiException;
 
 /**
  * Class EngineTest.

--- a/tests/Integration/EventListener/DoctrineEventSubscriberTest.php
+++ b/tests/Integration/EventListener/DoctrineEventSubscriberTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Integration\EventListener;
+namespace Meilisearch\Bundle\Test\Integration\EventListener;
 
 use Doctrine\ORM\Event\LifecycleEventArgs;
-use MeiliSearch\Bundle\EventListener\DoctrineEventSubscriber;
-use MeiliSearch\Bundle\Test\BaseKernelTestCase;
-use MeiliSearch\Bundle\Test\Entity\Page;
-use MeiliSearch\Bundle\Test\Entity\Post;
-use MeiliSearch\Client;
+use Meilisearch\Bundle\EventListener\DoctrineEventSubscriber;
+use Meilisearch\Bundle\Test\BaseKernelTestCase;
+use Meilisearch\Bundle\Test\Entity\Page;
+use Meilisearch\Bundle\Test\Entity\Post;
+use Meilisearch\Client;
 
 class DoctrineEventSubscriberTest extends BaseKernelTestCase
 {

--- a/tests/Integration/SearchTest.php
+++ b/tests/Integration/SearchTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Integration;
+namespace Meilisearch\Bundle\Test\Integration;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\Persistence\ObjectManager;
-use MeiliSearch\Bundle\Test\BaseKernelTestCase;
-use MeiliSearch\Bundle\Test\Entity\Post;
-use MeiliSearch\Bundle\Test\Entity\Tag;
-use MeiliSearch\Client;
-use MeiliSearch\Endpoints\Indexes;
-use MeiliSearch\Exceptions\ApiException;
+use Meilisearch\Bundle\Test\BaseKernelTestCase;
+use Meilisearch\Bundle\Test\Entity\Post;
+use Meilisearch\Bundle\Test\Entity\Tag;
+use Meilisearch\Client;
+use Meilisearch\Endpoints\Indexes;
+use Meilisearch\Exceptions\ApiException;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -67,12 +67,12 @@ class SearchTest extends BaseKernelTestCase
 
         $output = $commandTester->getDisplay();
 
-        $this->assertStringContainsString('Importing for index MeiliSearch\Bundle\Test\Entity\Post', $output);
-        $this->assertStringContainsString('Importing for index MeiliSearch\Bundle\Test\Entity\Tag', $output);
-        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' MeiliSearch\Bundle\Test\Entity\Post entities into sf_phpunit__posts index', $output);
-        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' MeiliSearch\Bundle\Test\Entity\Post entities into sf_phpunit__'.self::$indexName.' index', $output);
-        $this->assertStringContainsString('Indexed 1 / 1 MeiliSearch\Bundle\Test\Entity\Tag entities into sf_phpunit__tags index', $output);
-        $this->assertStringContainsString('Indexed 1 / 1 MeiliSearch\Bundle\Test\Entity\Tag entities into sf_phpunit__'.self::$indexName.' index', $output);
+        $this->assertStringContainsString('Importing for index Meilisearch\Bundle\Test\Entity\Post', $output);
+        $this->assertStringContainsString('Importing for index Meilisearch\Bundle\Test\Entity\Tag', $output);
+        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' Meilisearch\Bundle\Test\Entity\Post entities into sf_phpunit__posts index', $output);
+        $this->assertStringContainsString('Indexed '.$i.' / '.$i.' Meilisearch\Bundle\Test\Entity\Post entities into sf_phpunit__'.self::$indexName.' index', $output);
+        $this->assertStringContainsString('Indexed 1 / 1 Meilisearch\Bundle\Test\Entity\Tag entities into sf_phpunit__tags index', $output);
+        $this->assertStringContainsString('Indexed 1 / 1 Meilisearch\Bundle\Test\Entity\Tag entities into sf_phpunit__'.self::$indexName.' index', $output);
         $this->assertStringContainsString('Done!', $output);
 
         $searchTerm = 'Test';

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Integration;
+namespace Meilisearch\Bundle\Test\Integration;
 
-use MeiliSearch\Bundle\Test\BaseKernelTestCase;
-use MeiliSearch\Client;
-use MeiliSearch\Contracts\Index\TypoTolerance;
+use Meilisearch\Bundle\Test\BaseKernelTestCase;
+use Meilisearch\Client;
+use Meilisearch\Contracts\Index\TypoTolerance;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 

--- a/tests/Kernel.php
+++ b/tests/Kernel.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test;
+namespace Meilisearch\Bundle\Test;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
-use MeiliSearch\Bundle\MeiliSearchBundle;
+use Meilisearch\Bundle\MeilisearchBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
@@ -26,7 +26,7 @@ class Kernel extends HttpKernel
         return [
             new FrameworkBundle(),
             new DoctrineBundle(),
-            new MeiliSearchBundle(),
+            new MeilisearchBundle(),
         ];
     }
 
@@ -34,6 +34,6 @@ class Kernel extends HttpKernel
     {
         $loader->load(__DIR__.'/config/config.yaml');
         $loader->load(__DIR__.'/../src/Resources/config/services.xml');
-        $loader->load(__DIR__.'/config/meili_search.yaml');
+        $loader->load(__DIR__.'/config/meilisearch.yaml');
     }
 }

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Unit;
+namespace Meilisearch\Bundle\Test\Unit;
 
-use MeiliSearch\Bundle\DependencyInjection\Configuration;
+use Meilisearch\Bundle\DependencyInjection\Configuration;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**

--- a/tests/Unit/SerializationTest.php
+++ b/tests/Unit/SerializationTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Bundle\Test\Unit;
+namespace Meilisearch\Bundle\Test\Unit;
 
-use MeiliSearch\Bundle\Searchable;
-use MeiliSearch\Bundle\SearchableEntity;
-use MeiliSearch\Bundle\Test\Entity\Comment;
-use MeiliSearch\Bundle\Test\Entity\Post;
+use Meilisearch\Bundle\Searchable;
+use Meilisearch\Bundle\SearchableEntity;
+use Meilisearch\Bundle\Test\Entity\Comment;
+use Meilisearch\Bundle\Test\Entity\Post;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;

--- a/tests/config/config.yaml
+++ b/tests/config/config.yaml
@@ -18,5 +18,5 @@ doctrine:
                 is_bundle: false
                 type: annotation
                 dir: '%kernel.project_dir%/tests/Entity'
-                prefix: 'MeiliSearch\Bundle\Test\Entity'
+                prefix: 'Meilisearch\Bundle\Test\Entity'
                 alias: App

--- a/tests/config/meilisearch.yaml
+++ b/tests/config/meilisearch.yaml
@@ -1,4 +1,4 @@
-meili_search:
+meilisearch:
     url: '%env(MEILISEARCH_URL)%'
     api_key: '%env(MEILISEARCH_API_KEY)%'
     prefix: '%env(MEILISEARCH_PREFIX)%_'
@@ -6,7 +6,7 @@ meili_search:
     batchSize: 100
     indices:
         -   name: posts
-            class: 'MeiliSearch\Bundle\Test\Entity\Post'
+            class: 'Meilisearch\Bundle\Test\Entity\Post'
             enable_serializer_groups: true
             settings:
                 stopWords: ['the', 'a', 'an']
@@ -19,18 +19,18 @@ meili_search:
                         oneTypo: 5
                         twoTypos: 9
         -   name: comments
-            class: 'MeiliSearch\Bundle\Test\Entity\Comment'
+            class: 'Meilisearch\Bundle\Test\Entity\Comment'
         -   name: aggregated
-            class: 'MeiliSearch\Bundle\Test\Entity\ContentAggregator'
+            class: 'Meilisearch\Bundle\Test\Entity\ContentAggregator'
             index_if: isVisible
         -   name: tags
-            class: 'MeiliSearch\Bundle\Test\Entity\Tag'
+            class: 'Meilisearch\Bundle\Test\Entity\Tag'
             index_if: isPublic
         # Yes, we want to have links in the same index as tags
         # We just set the same index name 'tags'
         -   name: tags
-            class: 'MeiliSearch\Bundle\Test\Entity\Link'
+            class: 'Meilisearch\Bundle\Test\Entity\Link'
             index_if: isSponsored
         -   name: pages
-            class: 'MeiliSearch\Bundle\Test\Entity\Page'
+            class: 'Meilisearch\Bundle\Test\Entity\Page'
             enable_serializer_groups: true


### PR DESCRIPTION
Move every occurrence of `MeiliSearch` to `Meilisearch`, files included.
Breaking change in the `meili_search.yaml` to `meilisearch.yml` and the root key from `meili_search` to `meilisearch`.

Also, fixes #215 