### PR TITLE
Fix normalization with NormalizableInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
   "config": {
     "sort-packages": true,
     "allow-plugins": {
-      "phpstan/extension-installer": true
+      "phpstan/extension-installer": true,
+      "php-http/discovery": true
     }
   },
   "scripts": {

--- a/src/Services/MeilisearchService.php
+++ b/src/Services/MeilisearchService.php
@@ -16,14 +16,14 @@ use Meilisearch\Bundle\SearchService;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
-use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * Class MeilisearchService.
  */
 final class MeilisearchService implements SearchService
 {
-    private SerializerInterface $normalizer;
+    private NormalizerInterface $normalizer;
     private Engine $engine;
     private Collection $configuration;
     private PropertyAccessor $propertyAccessor;
@@ -33,7 +33,7 @@ final class MeilisearchService implements SearchService
     private array $classToSerializerGroupMapping;
     private array $indexIfMapping;
 
-    public function __construct(SerializerInterface $normalizer, Engine $engine, array $configuration)
+    public function __construct(NormalizerInterface $normalizer, Engine $engine, array $configuration)
     {
         $this->normalizer = $normalizer;
         $this->engine = $engine;

--- a/tests/Entity/SelfNormalizable.php
+++ b/tests/Entity/SelfNormalizable.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Tests\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Meilisearch\Bundle\Searchable;
+use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @ORM\Entity
+ */
+class SelfNormalizable implements NormalizableInterface
+{
+    /**
+     * @ORM\Id
+     *
+     * @ORM\Column(type="integer")
+     */
+    private int $id;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private string $name;
+
+    /**
+     * @ORM\Column(type="datetime_immutable")
+     */
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(int $id, string $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = []): array
+    {
+        if (Searchable::NORMALIZATION_FORMAT === $format) {
+            return [
+                'id' => $this->id,
+                'name' => 'this test is correct',
+                'self_normalized' => true,
+            ];
+        }
+
+        return [];
+    }
+}

--- a/tests/config/meilisearch.yaml
+++ b/tests/config/meilisearch.yaml
@@ -34,3 +34,5 @@ meilisearch:
         -   name: pages
             class: 'Meilisearch\Bundle\Tests\Entity\Page'
             enable_serializer_groups: true
+        -   name: self_normalizable
+            class: 'Meilisearch\Bundle\Tests\Entity\SelfNormalizable'


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #228

## What does this PR do?
- Starts taking into account `Symfony\Component\Serializer\Normalizer\NormalizableInterface` when indexing documents

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

