### PR TITLE
Require explicitly the PHP v8 polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "doctrine/doctrine-bundle": "^2.4",
     "meilisearch/meilisearch-php": "^1.0.0",
     "symfony/filesystem": "^4.4 || ^5.0 || ^6.0",
+    "symfony/polyfill-php80": "^1.27",
     "symfony/property-access": "^4.4 || ^5.0 || ^6.0",
     "symfony/serializer": "^4.4 || ^5.0 || ^6.0"
   },


### PR DESCRIPTION
# Pull Request

as the class `MeilisearchExtension` calls `str_starts_with` ([doc](https://www.php.net/manual/en/function.str-starts-with.php))
This polyfill must be required explicitly imho (not via transient deps)

obviously feel free to close, spotted while checking codebases related to this issue https://github.com/meilisearch/meilisearch-symfony/issues/263