### PR TITLE
Avoid using deprecated dbal `object` type

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,10 @@ indent_style             = space
 indent_size              = 4
 max_line_length          = 120
 
-[*.{yml,yaml,json}]
+[*.{yml,yaml}]
+indent_size              = 4
+
+[*.json]
 indent_size              = 2
 
 [*.{neon,neon.dist}]

--- a/tests/Dbal/Type/DummyObjectIdType.php
+++ b/tests/Dbal/Type/DummyObjectIdType.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Tests\Dbal\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Meilisearch\Bundle\Tests\Entity\ObjectId\DummyObjectId;
+
+final class DummyObjectIdType extends Type
+{
+    public function getName(): string
+    {
+        return 'dummy_object_id';
+    }
+
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getIntegerTypeDeclarationSQL($column);
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?DummyObjectId
+    {
+        if ($value instanceof DummyObjectId || null === $value) {
+            return $value;
+        }
+
+        if (!\is_string($value) && !is_int($value)) {
+            throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'string', 'int', DummyObjectId::class]);
+        }
+
+        return new DummyObjectId((int) $value);
+    }
+
+    /**
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?int
+    {
+        if ($value instanceof DummyObjectId) {
+            return $value->toInt();
+        }
+
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        if (!\is_string($value) && !is_int($value)) {
+            throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'string', 'int', DummyObjectId::class]);
+        }
+
+        return (int) $value;
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
+}

--- a/tests/Entity/ObjectId/DummyObjectId.php
+++ b/tests/Entity/ObjectId/DummyObjectId.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Meilisearch\Bundle\Tests\Entity\ObjectId;
 
-class DummyObjectId
+final class DummyObjectId
 {
     private int $id;
 
@@ -13,7 +13,12 @@ class DummyObjectId
         $this->id = $id;
     }
 
-    public function __toString()
+    public function toInt(): int
+    {
+        return $this->id;
+    }
+
+    public function __toString(): string
     {
         return (string) $this->id;
     }

--- a/tests/Entity/Page.php
+++ b/tests/Entity/Page.php
@@ -22,11 +22,11 @@ class Page
      *
      * @ORM\GeneratedValue(strategy="NONE")
      *
-     * @ORM\Column(type="object")
+     * @ORM\Column(type="dummy_object_id")
      */
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
-    #[ORM\Column(type: Types::OBJECT)]
+    #[ORM\Column(type: 'dummy_object_id')]
     private $id;
 
     /**

--- a/tests/Integration/EventListener/DoctrineEventSubscriberTest.php
+++ b/tests/Integration/EventListener/DoctrineEventSubscriberTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Meilisearch\Bundle\Tests\Integration\EventListener;
 
 use Meilisearch\Bundle\Tests\BaseKernelTestCase;
+use Meilisearch\Bundle\Tests\Entity\ObjectId\DummyObjectId;
 use Meilisearch\Bundle\Tests\Entity\Page;
 use Meilisearch\Bundle\Tests\Entity\Post;
 
@@ -31,7 +32,7 @@ class DoctrineEventSubscriberTest extends BaseKernelTestCase
         $result = $this->searchService->search($this->entityManager, Page::class, $page->getTitle());
 
         $this->assertCount(1, $result);
-        $this->assertEquals($page->getId(), $result[0]->getId());
+        $this->assertEquals(new DummyObjectId(1), $result[0]->getId());
     }
 
     public function testPostUpdate(): void
@@ -68,7 +69,7 @@ class DoctrineEventSubscriberTest extends BaseKernelTestCase
         $result = $this->searchService->search($this->entityManager, Page::class, 'better');
 
         $this->assertCount(1, $result);
-        $this->assertEquals($page->getId(), $result[0]->getId());
+        $this->assertEquals(new DummyObjectId(1), $result[0]->getId());
         $this->assertSame('Better page', $result[0]->getTitle());
     }
 

--- a/tests/config/config.yaml
+++ b/tests/config/config.yaml
@@ -10,6 +10,8 @@ doctrine:
             default:
                 driver: pdo_sqlite
                 path: '%kernel.cache_dir%/test.sqlite'
+        types:
+            dummy_object_id: Meilisearch\Bundle\Tests\Dbal\Type\DummyObjectIdType
     orm:
         auto_generate_proxy_classes: true
         validate_xml_mapping: true

--- a/tests/config/config_php7.yaml
+++ b/tests/config/config_php7.yaml
@@ -15,6 +15,8 @@ doctrine:
             default:
                 driver: pdo_sqlite
                 path: '%kernel.cache_dir%/test.sqlite'
+        types:
+            dummy_object_id: Meilisearch\Bundle\Tests\Dbal\Type\DummyObjectIdType
     orm:
         auto_generate_proxy_classes: true
         validate_xml_mapping: true


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #287

## What does this PR do?
- Introduces a custom doctrine type instead of using a deprecated one for testing an object as a primary key of test entity.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
