### PR TITLE
chore: add testruns for PHP 8.3

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -18,7 +18,7 @@ jobs:
         php-versions: ['7.4', '8.0']
     name: integration-tests-against-rc (PHP ${{ matrix.php-versions }})
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           MEILI_NO_ANALYTICS: true
     strategy:
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3']
         include:
           - php-version: '7.4'
             sf-version: '4.4.*'
@@ -39,10 +39,12 @@ jobs:
             sf-version: '6.1.*'
           - php-version: '8.2'
             sf-version: '6.2.*'
+          - php-version: '8.3'
+            sf-version: '6.3.*'
 
     name: integration-tests (PHP ${{ matrix.php-version }}) (Symfony ${{ matrix.sf-version }})
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -65,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Code style'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -94,7 +96,7 @@ jobs:
     name: Yaml linting check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Yaml lint check
         uses: ibiqlik/action-yamllint@v3
         with:

--- a/bors.toml
+++ b/bors.toml
@@ -3,6 +3,7 @@ status = [
     'integration-tests (PHP 8.0) (Symfony 6.0.*)',
     'integration-tests (PHP 8.1) (Symfony 6.1.*)',
     'integration-tests (PHP 8.2) (Symfony 6.2.*)',
+    'integration-tests (PHP 8.3) (Symfony 6.3.*)',
     'Code style'
 ]
 # 1 hour timeout


### PR DESCRIPTION
## What does this PR do?
- Add testrun for PHP 8.3 with symfony 6.3
- bump github actions/checkout v3 => v4

