### PR TITLE
Drop support of symfony 4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,11 @@ jobs:
           MEILI_MASTER_KEY: masterKey
           MEILI_NO_ANALYTICS: true
     strategy:
+      # only TEMP
+      fail-fast: false
       matrix:
         php-version: ['7.4', '8.0', '8.1', '8.2', '8.3']
         include:
-          - php-version: '7.4'
-            sf-version: '4.4.*'
           - php-version: '7.4'
             sf-version: '5.4.*'
           - php-version: '8.0'
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         env:
           SYMFONY_REQUIRE: ${{ matrix.sf-version }}
-        run: composer install --prefer-dist --no-progress --quiet
+        run: composer install --prefer-dist --no-progress
       - name: "Remove doctrine/annotations"
         if: matrix.php-version != '7.4'
         run: |

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ Say goodbye to server deployment and manual updates with [Meilisearch Cloud](htt
 ## 📝 Requirements
 
 * **Require** PHP 7.4 and later.
-* **Compatible** with Symfony 4.0 and later.
+* **Compatible** with Symfony 5.4 and later.
 * **Support** Doctrine ORM.
+
+For support of older versions, see older versions of this bundle.
 
 ## 🤖 Compatibility with Meilisearch
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,4 @@
 status = [
-    'integration-tests (PHP 7.4) (Symfony 4.4.*)',
     'integration-tests (PHP 7.4) (Symfony 5.4.*)',
     'integration-tests (PHP 8.0) (Symfony 6.0.*)',
     'integration-tests (PHP 8.1) (Symfony 6.1.*)',

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
     "ext-json": "*",
     "doctrine/doctrine-bundle": "^2.4",
     "meilisearch/meilisearch-php": "^1.0.0",
-    "symfony/filesystem": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+    "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
     "symfony/polyfill-php80": "^1.27",
-    "symfony/property-access": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-    "symfony/serializer": "^4.4 || ^5.0 || ^6.0 || ^7.0"
+    "symfony/property-access": "^5.4 || ^6.0 || ^7.0",
+    "symfony/serializer": "^5.4 || ^6.0 || ^7.0"
   },
   "require-dev": {
     "doctrine/annotations": "^2.0",
@@ -40,10 +40,10 @@
     "phpstan/phpstan-phpunit": "^1.3.10",
     "phpstan/phpstan-symfony": "^1.2.23",
     "phpunit/php-code-coverage": "^9.2.26",
-    "symfony/doctrine-bridge": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-    "symfony/http-client": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-    "symfony/phpunit-bridge": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-    "symfony/yaml": "^4.4 || ^5.0 || ^6.0 || ^7.0"
+    "symfony/doctrine-bridge": "^5.4 || ^6.0 || ^7.0",
+    "symfony/http-client": "^5.4 || ^6.0 || ^7.0",
+    "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0",
+    "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Blocked by
- [x] matthiasnoback/symfony-dependency-injection-testsing 
- [x] https://github.com/php-http/client-common/pull/232

please see
https://github.com/meilisearch/meilisearch-symfony/pull/265#issuecomment-1788661930
and https://github.com/meilisearch/meilisearch-symfony/issues/300