### PR TITLE
Fix(serializer): Properly normalize `DateTimeInterface` objects

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -66,5 +66,9 @@
             <argument type="service" id="meilisearch.client" />
             <tag name="console.command" />
         </service>
+
+        <service id="Meilisearch\Bundle\Services\UnixTimestampNormalizer">
+            <tag name="serializer.normalizer" />
+        </service>
     </services>
 </container>

--- a/src/SearchableEntity.php
+++ b/src/SearchableEntity.php
@@ -61,6 +61,7 @@ final class SearchableEntity
     public function getSearchableArray(): array
     {
         $context = [
+            'meilisearch' => true,
             'fieldsMapping' => $this->entityMetadata->fieldMappings,
         ];
 

--- a/src/Services/UnixTimestampNormalizer.php
+++ b/src/Services/UnixTimestampNormalizer.php
@@ -13,7 +13,7 @@ final class UnixTimestampNormalizer implements NormalizerInterface
      */
     public function normalize(mixed $object, string $format = null, array $context = []): int
     {
-        return (int) $object->format('U');
+        return $object->getTimestamp();
     }
 
     public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool

--- a/src/Services/UnixTimestampNormalizer.php
+++ b/src/Services/UnixTimestampNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Services;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class UnixTimestampNormalizer implements NormalizerInterface
+{
+    /**
+     * @param \DateTimeInterface $object
+     */
+    public function normalize(mixed $object, string $format = null, array $context = []): int
+    {
+        return (int) $object->format('U');
+    }
+
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    {
+        return $data instanceof \DateTimeInterface && true === ($context['meilisearch'] ?? null);
+    }
+}

--- a/src/Services/UnixTimestampNormalizer.php
+++ b/src/Services/UnixTimestampNormalizer.php
@@ -23,4 +23,11 @@ final class UnixTimestampNormalizer implements NormalizerInterface
     {
         return $data instanceof \DateTimeInterface && true === ($context['meilisearch'] ?? null);
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            \DateTimeInterface::class => true, // @codeCoverageIgnore
+        ];
+    }
 }

--- a/src/Services/UnixTimestampNormalizer.php
+++ b/src/Services/UnixTimestampNormalizer.php
@@ -11,12 +11,15 @@ final class UnixTimestampNormalizer implements NormalizerInterface
     /**
      * @param \DateTimeInterface $object
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): int
+    public function normalize($object, string $format = null, array $context = []): int
     {
         return $object->getTimestamp();
     }
 
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    /**
+     * @param mixed $data
+     */
+    public function supportsNormalization($data, string $format = null, array $context = []): bool
     {
         return $data instanceof \DateTimeInterface && true === ($context['meilisearch'] ?? null);
     }

--- a/tests/Integration/CommandsTest.php
+++ b/tests/Integration/CommandsTest.php
@@ -440,13 +440,13 @@ EOD, $importOutput);
                 'objectID' => 1,
                 'id' => 1,
                 'name' => 'Dummy 1',
-                'createdAt' => '2024-04-04T07:32:01+00:00',
+                'createdAt' => 1712215921,
             ],
             [
                 'objectID' => 2,
                 'id' => 2,
                 'name' => 'Dummy 2',
-                'createdAt' => '2024-04-04T07:32:02+00:00',
+                'createdAt' => 1712215922,
             ],
         ], $this->client->index('sf_phpunit__dummy_custom_groups')->getDocuments()->getResults());
     }

--- a/tests/Unit/SerializationTest.php
+++ b/tests/Unit/SerializationTest.php
@@ -18,10 +18,6 @@ class SerializationTest extends KernelTestCase
     public function testSimpleEntityToSearchableArray(): void
     {
         $datetime = new \DateTime();
-        $dateNormalizer = static::getContainer()->get('serializer.normalizer.datetime');
-        // This way we can test that DateTime's are serialized with DateTimeNormalizer
-        // And not the default ObjectNormalizer
-        $serializedDateTime = $dateNormalizer->normalize($datetime, Searchable::NORMALIZATION_FORMAT);
 
         $post = new Post(
             [
@@ -51,12 +47,12 @@ class SerializationTest extends KernelTestCase
             'id' => 12,
             'title' => 'a simple post',
             'content' => 'some text',
-            'publishedAt' => $serializedDateTime,
+            'publishedAt' => (int) $datetime->format('U'),
             'comments' => [
                 [
                     'id' => null,
                     'content' => 'a great comment',
-                    'publishedAt' => $serializedDateTime,
+                    'publishedAt' => (int) $datetime->format('U'),
                 ],
             ],
         ];

--- a/tests/Unit/SerializationTest.php
+++ b/tests/Unit/SerializationTest.php
@@ -47,12 +47,12 @@ class SerializationTest extends KernelTestCase
             'id' => 12,
             'title' => 'a simple post',
             'content' => 'some text',
-            'publishedAt' => (int) $datetime->format('U'),
+            'publishedAt' => $datetime->getTimestamp(),
             'comments' => [
                 [
                     'id' => null,
                     'content' => 'a great comment',
-                    'publishedAt' => (int) $datetime->format('U'),
+                    'publishedAt' => $datetime->getTimestamp(),
                 ],
             ],
         ];


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #304 

## What does this PR do?
- `DateTimeInterface` objects are now normalized as unix timestamps integers, in the context of a serialization initiated by this bundle.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
