### PR TITLE
Add SettingsUpdater service

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -44,6 +44,13 @@
         </service>
         <service id="Meilisearch\Bundle\SearchService" alias="meilisearch.service" />
 
+        <service id="meilisearch.settings_updater" class="Meilisearch\Bundle\Services\SettingsUpdater">
+            <argument type="service" id="meilisearch.service" />
+            <argument type="service" id="meilisearch.client" />
+            <argument type="service" id="event_dispatcher" />
+        </service>
+        <service id="Meilisearch\Bundle\Services\SettingsUpdater" alias="meilisearch.settings_updater" />
+
         <service id="Meilisearch\Bundle\Command\MeilisearchClearCommand">
             <argument type="service" id="meilisearch.service" />
             <tag name="console.command" />
@@ -52,6 +59,8 @@
         <service id="Meilisearch\Bundle\Command\MeilisearchCreateCommand">
             <argument type="service" id="meilisearch.service" />
             <argument type="service" id="meilisearch.client" />
+            <argument type="service" id="meilisearch.settings_updater" />
+            <argument type="service" id="event_dispatcher" />
             <tag name="console.command" />
         </service>
 
@@ -64,6 +73,8 @@
             <argument type="service" id="meilisearch.service" />
             <argument type="service" id="doctrine" />
             <argument type="service" id="meilisearch.client" />
+            <argument type="service" id="meilisearch.settings_updater" />
+            <argument type="service" id="event_dispatcher" />
             <tag name="console.command" />
         </service>
 

--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -12,8 +12,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class IndexCommand extends Command
 {
-    private string $prefix;
+    protected const DEFAULT_RESPONSE_TIMEOUT = 5000;
+
     protected SearchService $searchService;
+
+    private string $prefix;
 
     public function __construct(SearchService $searchService)
     {

--- a/src/Command/MeilisearchCreateCommand.php
+++ b/src/Command/MeilisearchCreateCommand.php
@@ -5,25 +5,30 @@ declare(strict_types=1);
 namespace Meilisearch\Bundle\Command;
 
 use Meilisearch\Bundle\Collection;
-use Meilisearch\Bundle\Exception\InvalidSettingName;
-use Meilisearch\Bundle\Exception\TaskException;
+use Meilisearch\Bundle\EventListener\ConsoleOutputSubscriber;
 use Meilisearch\Bundle\Model\Aggregator;
 use Meilisearch\Bundle\SearchService;
-use Meilisearch\Bundle\SettingsProvider;
+use Meilisearch\Bundle\Services\SettingsUpdater;
 use Meilisearch\Client;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class MeilisearchCreateCommand extends IndexCommand
 {
     private Client $searchClient;
+    private SettingsUpdater $settingsUpdater;
+    private EventDispatcherInterface $eventDispatcher;
 
-    public function __construct(SearchService $searchService, Client $searchClient)
+    public function __construct(SearchService $searchService, Client $searchClient, SettingsUpdater $settingsUpdater, EventDispatcherInterface $eventDispatcher)
     {
         parent::__construct($searchService);
 
         $this->searchClient = $searchClient;
+        $this->settingsUpdater = $settingsUpdater;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public static function getDefaultName(): string
@@ -40,33 +45,32 @@ final class MeilisearchCreateCommand extends IndexCommand
     {
         $this
             ->setDescription(self::getDefaultDescription())
-            ->addOption('indices', 'i', InputOption::VALUE_OPTIONAL, 'Comma-separated list of index names');
-    }
-
-    private function entitiesToIndex($indexes): array
-    {
-        foreach ($indexes as $key => $index) {
-            $entityClassName = $index['class'];
-            if (is_subclass_of($entityClassName, Aggregator::class)) {
-                $indexes->forget($key);
-
-                $indexes = new Collection(array_merge(
-                    $indexes->all(),
-                    array_map(
-                        static fn ($entity) => ['name' => $index['name'], 'class' => $entity],
-                        $entityClassName::getEntities()
-                    )
-                ));
-            }
-        }
-
-        return array_unique($indexes->all(), SORT_REGULAR);
+            ->addOption('indices', 'i', InputOption::VALUE_OPTIONAL, 'Comma-separated list of index names')
+            ->addOption(
+                'update-settings',
+                null,
+                InputOption::VALUE_NEGATABLE,
+                'Update settings related to indices to the search engine',
+                true
+            )
+            ->addOption(
+                'response-timeout',
+                't',
+                InputOption::VALUE_REQUIRED,
+                'Timeout (in ms) to get response from the search engine',
+                self::DEFAULT_RESPONSE_TIMEOUT
+            )
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->eventDispatcher->addSubscriber(new ConsoleOutputSubscriber(new SymfonyStyle($input, $output)));
+
         $indexes = $this->getEntitiesFromArgs($input, $output);
         $entitiesToIndex = $this->entitiesToIndex($indexes);
+        $updateSettings = $input->getOption('update-settings');
+        $responseTimeout = ((int) $input->getOption('response-timeout')) ?: self::DEFAULT_RESPONSE_TIMEOUT;
 
         /** @var array $index */
         foreach ($entitiesToIndex as $index) {
@@ -79,41 +83,38 @@ final class MeilisearchCreateCommand extends IndexCommand
             $output->writeln('<info>Creating index '.$index['name'].' for '.$entityClassName.'</info>');
 
             $task = $this->searchClient->createIndex($index['name']);
-            $this->searchClient->waitForTask($task['taskUid']);
-            $indexInstance = $this->searchClient->index($index['name']);
+            $this->searchClient->waitForTask($task['taskUid'], $responseTimeout);
 
-            if (isset($index['settings']) && is_array($index['settings'])) {
-                foreach ($index['settings'] as $variable => $value) {
-                    $method = sprintf('update%s', ucfirst($variable));
-
-                    if (!method_exists($indexInstance, $method)) {
-                        throw new InvalidSettingName(sprintf('Invalid setting name: "%s"', $variable));
-                    }
-
-                    if (isset($value['_service']) && $value['_service'] instanceof SettingsProvider) {
-                        $value = $value['_service']();
-                    } elseif ('distinctAttribute' === $variable && is_array($value)) {
-                        $value = $value[0] ?? null;
-                    }
-
-                    // Update
-                    $task = $indexInstance->{$method}($value);
-
-                    // Get task information using uid
-                    $indexInstance->waitForTask($task['taskUid']);
-                    $task = $indexInstance->getTask($task['taskUid']);
-
-                    if ('failed' === $task['status']) {
-                        throw new TaskException($task['error']);
-                    }
-
-                    $output->writeln('<info>Settings updated of "'.$index['name'].'".</info>');
-                }
+            if ($updateSettings) {
+                $this->settingsUpdater->update($index['name'], $responseTimeout);
             }
         }
 
         $output->writeln('<info>Done!</info>');
 
         return 0;
+    }
+
+    private function entitiesToIndex($indexes): array
+    {
+        foreach ($indexes as $key => $index) {
+            $entityClassName = $index['class'];
+
+            if (!is_subclass_of($entityClassName, Aggregator::class)) {
+                continue;
+            }
+
+            $indexes->forget($key);
+
+            $indexes = new Collection(array_merge(
+                $indexes->all(),
+                array_map(
+                    static fn ($entity) => ['name' => $index['name'], 'prefixed_name' => $index['prefixed_name'], 'class' => $entity],
+                    $entityClassName::getEntities()
+                )
+            ));
+        }
+
+        return array_unique($indexes->all(), SORT_REGULAR);
     }
 }

--- a/src/DependencyInjection/MeilisearchExtension.php
+++ b/src/DependencyInjection/MeilisearchExtension.php
@@ -26,6 +26,7 @@ final class MeilisearchExtension extends Extension
         }
 
         foreach ($config['indices'] as $index => $indice) {
+            $config['indices'][$index]['prefixed_name'] = $config['prefix'].$indice['name'];
             $config['indices'][$index]['settings'] = $this->findReferences($config['indices'][$index]['settings']);
         }
 

--- a/src/Event/SettingsUpdatedEvent.php
+++ b/src/Event/SettingsUpdatedEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class SettingsUpdatedEvent extends Event
+{
+    /**
+     * @var class-string
+     */
+    private string $class;
+
+    /**
+     * @var non-empty-string
+     */
+    private string $index;
+
+    /**
+     * @param class-string     $class
+     * @param non-empty-string $index
+     */
+    public function __construct(string $class, string $index)
+    {
+        $this->index = $index;
+        $this->class = $class;
+    }
+
+    /**
+     * @return class-string
+     */
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getIndex(): string
+    {
+        return $this->index;
+    }
+}

--- a/src/EventListener/ConsoleOutputSubscriber.php
+++ b/src/EventListener/ConsoleOutputSubscriber.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\EventListener;
+
+use Meilisearch\Bundle\Event\SettingsUpdatedEvent;
+use Symfony\Component\Console\Style\OutputStyle;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class ConsoleOutputSubscriber implements EventSubscriberInterface
+{
+    private OutputStyle $io;
+
+    public function __construct(OutputStyle $io)
+    {
+        $this->io = $io;
+    }
+
+    public function afterSettingsUpdate(SettingsUpdatedEvent $event): void
+    {
+        $this->io->writeln('<info>Settings updated of "'.$event->getIndex().'".</info>');
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SettingsUpdatedEvent::class => 'afterSettingsUpdate',
+        ];
+    }
+}

--- a/src/Exception/InvalidIndiceException.php
+++ b/src/Exception/InvalidIndiceException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Exception;
+
+final class InvalidIndiceException extends \InvalidArgumentException
+{
+    public function __construct(string $indice, $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(sprintf('Meilisearch index for "%s" was not found.', $indice), $code, $previous);
+    }
+}

--- a/src/Services/SettingsUpdater.php
+++ b/src/Services/SettingsUpdater.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Services;
+
+use Meilisearch\Bundle\Collection;
+use Meilisearch\Bundle\Event\SettingsUpdatedEvent;
+use Meilisearch\Bundle\Exception\InvalidIndiceException;
+use Meilisearch\Bundle\Exception\InvalidSettingName;
+use Meilisearch\Bundle\Exception\TaskException;
+use Meilisearch\Bundle\SearchService;
+use Meilisearch\Bundle\SettingsProvider;
+use Meilisearch\Client;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class SettingsUpdater
+{
+    private const DEFAULT_RESPONSE_TIMEOUT = 5000;
+
+    private Client $searchClient;
+    private EventDispatcherInterface $eventDispatcher;
+    private Collection $configuration;
+
+    public function __construct(SearchService $searchService, Client $searchClient, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->searchClient = $searchClient;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->configuration = $searchService->getConfiguration();
+    }
+
+    /**
+     * @param non-empty-string  $indice
+     * @param positive-int|null $responseTimeout
+     */
+    public function update(string $indice, ?int $responseTimeout = null): void
+    {
+        $index = (new Collection($this->configuration->get('indices')))->firstWhere('prefixed_name', $indice);
+
+        if (!is_array($index)) {
+            throw new InvalidIndiceException($indice);
+        }
+
+        if (!is_array($index['settings'] ?? null) || [] === $index['settings']) {
+            return;
+        }
+
+        $indexName = $index['prefixed_name'];
+        $indexInstance = $this->searchClient->index($indexName);
+        $responseTimeout = $responseTimeout ?? self::DEFAULT_RESPONSE_TIMEOUT;
+
+        foreach ($index['settings'] as $variable => $value) {
+            $method = sprintf('update%s', ucfirst($variable));
+
+            if (!method_exists($indexInstance, $method)) {
+                throw new InvalidSettingName(sprintf('Invalid setting name: "%s"', $variable));
+            }
+
+            if (isset($value['_service']) && $value['_service'] instanceof SettingsProvider) {
+                $value = $value['_service']();
+            } elseif ('distinctAttribute' === $variable && is_array($value)) {
+                $value = $value[0] ?? null;
+            }
+
+            // Update
+            $task = $indexInstance->{$method}($value);
+
+            // Get task information using uid
+            $indexInstance->waitForTask($task['taskUid'], $responseTimeout);
+            $task = $indexInstance->getTask($task['taskUid']);
+
+            if ('failed' === $task['status']) {
+                throw new TaskException($task['error']);
+            }
+
+            $this->eventDispatcher->dispatch(new SettingsUpdatedEvent($index['class'], $indexName));
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Allows to reuse settings updating code between `meilisearch:create` and `meilisearch:import` commands;
- Allows to update settings outside meilisearch bundle;
- Respects `--update-settings` option in `meilisearch:import` command and for consistency also added to `meilisearch:create`;
  **Note: to avoid BC break, because settings were always updated, I've changed `update-settings` option to `negatable` mode, so basically running command without it is like passing `--update-settings` to command and to allow skipping settings update there is now `--no-settings-update` option automatically added and handled by Symfony.**

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
