### PR TITLE
Update settings once per index

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,6 +8,7 @@ $finder = PhpCsFixer\Finder::create()
     ->append([__FILE__]);
 
 return (new PhpCsFixer\Config())
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRiskyAllowed(true)
     ->setFinder($finder)
     ->setRules([

--- a/config/services.xml
+++ b/config/services.xml
@@ -78,6 +78,13 @@
             <tag name="console.command" />
         </service>
 
+        <service id="Meilisearch\Bundle\Command\MeilisearchUpdateSettingsCommand">
+            <argument type="service" id="meilisearch.service" />
+            <argument type="service" id="meilisearch.settings_updater" />
+            <argument type="service" id="event_dispatcher" />
+            <tag name="console.command" />
+        </service>
+
         <service id="Meilisearch\Bundle\Services\UnixTimestampNormalizer">
             <tag name="serializer.normalizer" />
         </service>

--- a/src/Command/MeilisearchImportCommand.php
+++ b/src/Command/MeilisearchImportCommand.php
@@ -141,14 +141,14 @@ final class MeilisearchImportCommand extends IndexCommand
                     );
                 }
 
-                if ($updateSettings) {
-                    $this->settingsUpdater->update($index['prefixed_name'], $responseTimeout);
-                }
-
                 ++$page;
             } while (count($entities) >= $batchSize);
 
             $manager->clear();
+
+            if ($updateSettings) {
+                $this->settingsUpdater->update($index['prefixed_name'], $responseTimeout);
+            }
         }
 
         $output->writeln('<info>Done!</info>');

--- a/src/Command/MeilisearchUpdateSettingsCommand.php
+++ b/src/Command/MeilisearchUpdateSettingsCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Command;
+
+use Meilisearch\Bundle\Collection;
+use Meilisearch\Bundle\EventListener\ConsoleOutputSubscriber;
+use Meilisearch\Bundle\Model\Aggregator;
+use Meilisearch\Bundle\SearchService;
+use Meilisearch\Bundle\Services\SettingsUpdater;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class MeilisearchUpdateSettingsCommand extends IndexCommand
+{
+    private SettingsUpdater $settingsUpdater;
+    private EventDispatcherInterface $eventDispatcher;
+
+    public function __construct(SearchService $searchService, SettingsUpdater $settingsUpdater, EventDispatcherInterface $eventDispatcher)
+    {
+        parent::__construct($searchService);
+
+        $this->settingsUpdater = $settingsUpdater;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public static function getDefaultName(): string
+    {
+        return 'meilisearch:update-settings';
+    }
+
+    public static function getDefaultDescription(): string
+    {
+        return 'Push settings to meilisearch';
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription(self::getDefaultDescription())
+            ->addOption('indices', 'i', InputOption::VALUE_OPTIONAL, 'Comma-separated list of index names')
+            ->addOption(
+                'response-timeout',
+                't',
+                InputOption::VALUE_REQUIRED,
+                'Timeout (in ms) to get response from the search engine',
+                self::DEFAULT_RESPONSE_TIMEOUT
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->eventDispatcher->addSubscriber(new ConsoleOutputSubscriber(new SymfonyStyle($input, $output)));
+
+        $indexes = $this->getEntitiesFromArgs($input, $output);
+        $entitiesToIndex = $this->entitiesToIndex($indexes);
+        $responseTimeout = ((int) $input->getOption('response-timeout')) ?: self::DEFAULT_RESPONSE_TIMEOUT;
+
+        /** @var array $index */
+        foreach ($entitiesToIndex as $index) {
+            $entityClassName = $index['class'];
+
+            if (!$this->searchService->isSearchable($entityClassName)) {
+                continue;
+            }
+
+            $this->settingsUpdater->update($index['prefixed_name'], $responseTimeout);
+        }
+
+        $output->writeln('<info>Done!</info>');
+
+        return 0;
+    }
+
+    private function entitiesToIndex($indexes): array
+    {
+        foreach ($indexes as $key => $index) {
+            $entityClassName = $index['class'];
+
+            if (!is_subclass_of($entityClassName, Aggregator::class)) {
+                continue;
+            }
+
+            $indexes->forget($key);
+
+            $indexes = new Collection(array_merge(
+                $indexes->all(),
+                array_map(
+                    static fn ($entity) => ['name' => $index['name'], 'prefixed_name' => $index['prefixed_name'], 'class' => $entity],
+                    $entityClassName::getEntities()
+                )
+            ));
+        }
+
+        return array_unique($indexes->all(), SORT_REGULAR);
+    }
+}

--- a/src/Event/SettingsUpdatedEvent.php
+++ b/src/Event/SettingsUpdatedEvent.php
@@ -19,13 +19,20 @@ final class SettingsUpdatedEvent extends Event
     private string $index;
 
     /**
+     * @var non-empty-string
+     */
+    private string $setting;
+
+    /**
      * @param class-string     $class
      * @param non-empty-string $index
+     * @param non-empty-string $setting
      */
-    public function __construct(string $class, string $index)
+    public function __construct(string $class, string $index, string $setting)
     {
         $this->index = $index;
         $this->class = $class;
+        $this->setting = $setting;
     }
 
     /**
@@ -42,5 +49,13 @@ final class SettingsUpdatedEvent extends Event
     public function getIndex(): string
     {
         return $this->index;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getSetting(): string
+    {
+        return $this->setting;
     }
 }

--- a/src/EventListener/ConsoleOutputSubscriber.php
+++ b/src/EventListener/ConsoleOutputSubscriber.php
@@ -19,7 +19,7 @@ final class ConsoleOutputSubscriber implements EventSubscriberInterface
 
     public function afterSettingsUpdate(SettingsUpdatedEvent $event): void
     {
-        $this->io->writeln('<info>Settings updated of "'.$event->getIndex().'".</info>');
+        $this->io->writeln('<info>Setting "'.$event->getSetting().'" updated of "'.$event->getIndex().'".</info>');
     }
 
     public static function getSubscribedEvents(): array

--- a/src/Services/SettingsUpdater.php
+++ b/src/Services/SettingsUpdater.php
@@ -73,7 +73,7 @@ final class SettingsUpdater
                 throw new TaskException($task['error']);
             }
 
-            $this->eventDispatcher->dispatch(new SettingsUpdatedEvent($index['class'], $indexName));
+            $this->eventDispatcher->dispatch(new SettingsUpdatedEvent($index['class'], $indexName, $variable));
         }
     }
 }

--- a/tests/Integration/Command/MeilisearchClearCommandTest.php
+++ b/tests/Integration/Command/MeilisearchClearCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Tests\Integration\Command;
+
+use Meilisearch\Bundle\Tests\BaseKernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class MeilisearchClearCommandTest extends BaseKernelTestCase
+{
+    protected Application $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->application = new Application(self::createKernel());
+    }
+
+    public function testClear(): void
+    {
+        $command = $this->application->find('meilisearch:clear');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $this->assertSame(<<<'EOD'
+Cleared sf_phpunit__posts index of Meilisearch\Bundle\Tests\Entity\Post
+Cleared sf_phpunit__comments index of Meilisearch\Bundle\Tests\Entity\Comment
+Cleared sf_phpunit__aggregated index of Meilisearch\Bundle\Tests\Entity\ContentAggregator
+Cleared sf_phpunit__tags index of Meilisearch\Bundle\Tests\Entity\Tag
+Cleared sf_phpunit__tags index of Meilisearch\Bundle\Tests\Entity\Link
+Cleared sf_phpunit__discriminator_map index of Meilisearch\Bundle\Tests\Entity\ContentItem
+Cleared sf_phpunit__pages index of Meilisearch\Bundle\Tests\Entity\Page
+Cleared sf_phpunit__self_normalizable index of Meilisearch\Bundle\Tests\Entity\SelfNormalizable
+Cleared sf_phpunit__dummy_custom_groups index of Meilisearch\Bundle\Tests\Entity\DummyCustomGroups
+Cleared sf_phpunit__dynamic_settings index of Meilisearch\Bundle\Tests\Entity\DynamicSettings
+Done!
+
+EOD, $commandTester->getDisplay());
+    }
+
+    public function testClearWithIndice(): void
+    {
+        $command = $this->application->find('meilisearch:clear');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['--indices' => 'posts']);
+
+        $this->assertSame(<<<'EOD'
+Cleared sf_phpunit__posts index of Meilisearch\Bundle\Tests\Entity\Post
+Done!
+
+EOD, $commandTester->getDisplay());
+    }
+
+    public function testClearUnknownIndex(): void
+    {
+        $command = $this->application->find('meilisearch:clear');
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            '--indices' => 'test',
+        ]);
+
+        $this->assertStringContainsString('Cannot clear index. Not found.', $commandTester->getDisplay());
+    }
+
+    public function testAlias(): void
+    {
+        $command = $this->application->find('meilisearch:clear');
+
+        self::assertSame(['meili:clear'], $command->getAliases());
+    }
+}

--- a/tests/Integration/Command/MeilisearchCreateCommandTest.php
+++ b/tests/Integration/Command/MeilisearchCreateCommandTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Tests\Integration\Command;
+
+use Meilisearch\Bundle\Tests\BaseKernelTestCase;
+use Meilisearch\Bundle\Tests\Entity\DynamicSettings;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class MeilisearchCreateCommandTest extends BaseKernelTestCase
+{
+    protected Application $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->application = new Application(self::createKernel());
+    }
+
+    public function testExecuteIndexCreation(): void
+    {
+        $createCommand = $this->application->find('meilisearch:create');
+        $createCommandTester = new CommandTester($createCommand);
+        $createCommandTester->execute([]);
+
+        $this->assertSame($this->client->getTasks()->getResults()[0]['type'], 'indexCreation');
+    }
+
+    /**
+     * @testWith [false]
+     *           [true]
+     */
+    public function testWithoutIndices(bool $updateSettings): void
+    {
+        $createCommand = $this->application->find('meilisearch:create');
+        $createCommandTester = new CommandTester($createCommand);
+        $createCommandTester->execute($updateSettings ? [] : ['--no-update-settings' => true]);
+
+        $createOutput = $createCommandTester->getDisplay();
+
+        if ($updateSettings) {
+            $this->assertSame(<<<'EOD'
+Creating index sf_phpunit__posts for Meilisearch\Bundle\Tests\Entity\Post
+Settings updated of "sf_phpunit__posts".
+Settings updated of "sf_phpunit__posts".
+Settings updated of "sf_phpunit__posts".
+Settings updated of "sf_phpunit__posts".
+Creating index sf_phpunit__comments for Meilisearch\Bundle\Tests\Entity\Comment
+Creating index sf_phpunit__tags for Meilisearch\Bundle\Tests\Entity\Tag
+Creating index sf_phpunit__tags for Meilisearch\Bundle\Tests\Entity\Link
+Creating index sf_phpunit__discriminator_map for Meilisearch\Bundle\Tests\Entity\ContentItem
+Creating index sf_phpunit__pages for Meilisearch\Bundle\Tests\Entity\Page
+Creating index sf_phpunit__self_normalizable for Meilisearch\Bundle\Tests\Entity\SelfNormalizable
+Creating index sf_phpunit__dummy_custom_groups for Meilisearch\Bundle\Tests\Entity\DummyCustomGroups
+Creating index sf_phpunit__dynamic_settings for Meilisearch\Bundle\Tests\Entity\DynamicSettings
+Settings updated of "sf_phpunit__dynamic_settings".
+Settings updated of "sf_phpunit__dynamic_settings".
+Settings updated of "sf_phpunit__dynamic_settings".
+Settings updated of "sf_phpunit__dynamic_settings".
+Creating index sf_phpunit__aggregated for Meilisearch\Bundle\Tests\Entity\Post
+Creating index sf_phpunit__aggregated for Meilisearch\Bundle\Tests\Entity\Tag
+Done!
+
+EOD, $createOutput);
+        } else {
+            $this->assertSame(<<<'EOD'
+Creating index sf_phpunit__posts for Meilisearch\Bundle\Tests\Entity\Post
+Creating index sf_phpunit__comments for Meilisearch\Bundle\Tests\Entity\Comment
+Creating index sf_phpunit__tags for Meilisearch\Bundle\Tests\Entity\Tag
+Creating index sf_phpunit__tags for Meilisearch\Bundle\Tests\Entity\Link
+Creating index sf_phpunit__discriminator_map for Meilisearch\Bundle\Tests\Entity\ContentItem
+Creating index sf_phpunit__pages for Meilisearch\Bundle\Tests\Entity\Page
+Creating index sf_phpunit__self_normalizable for Meilisearch\Bundle\Tests\Entity\SelfNormalizable
+Creating index sf_phpunit__dummy_custom_groups for Meilisearch\Bundle\Tests\Entity\DummyCustomGroups
+Creating index sf_phpunit__dynamic_settings for Meilisearch\Bundle\Tests\Entity\DynamicSettings
+Creating index sf_phpunit__aggregated for Meilisearch\Bundle\Tests\Entity\Post
+Creating index sf_phpunit__aggregated for Meilisearch\Bundle\Tests\Entity\Tag
+Done!
+
+EOD, $createOutput);
+        }
+    }
+
+    public function testWithIndices(): void
+    {
+        $createCommand = $this->application->find('meilisearch:create');
+        $createCommandTester = new CommandTester($createCommand);
+        $createCommandTester->execute([
+            '--indices' => 'posts',
+        ]);
+
+        $createOutput = $createCommandTester->getDisplay();
+
+        $this->assertSame(<<<'EOD'
+Creating index sf_phpunit__posts for Meilisearch\Bundle\Tests\Entity\Post
+Settings updated of "sf_phpunit__posts".
+Settings updated of "sf_phpunit__posts".
+Settings updated of "sf_phpunit__posts".
+Settings updated of "sf_phpunit__posts".
+Done!
+
+EOD, $createOutput);
+    }
+
+    public function testWithDynamicSettings(): void
+    {
+        for ($i = 0; $i <= 5; ++$i) {
+            $this->entityManager->persist(new DynamicSettings($i, "Dynamic $i"));
+        }
+
+        $this->entityManager->flush();
+
+        $importCommand = $this->application->find('meilisearch:create');
+        $importCommandTester = new CommandTester($importCommand);
+        $importCommandTester->execute(['--indices' => 'dynamic_settings']);
+
+        $importOutput = $importCommandTester->getDisplay();
+
+        $this->assertSame(<<<'EOD'
+Creating index sf_phpunit__dynamic_settings for Meilisearch\Bundle\Tests\Entity\DynamicSettings
+Settings updated of "sf_phpunit__dynamic_settings".
+Settings updated of "sf_phpunit__dynamic_settings".
+Settings updated of "sf_phpunit__dynamic_settings".
+Settings updated of "sf_phpunit__dynamic_settings".
+Done!
+
+EOD, $importOutput);
+
+        $settings = $this->get('meilisearch.client')->index('sf_phpunit__dynamic_settings')->getSettings();
+
+        $getSetting = static fn ($value) => $value instanceof \IteratorAggregate ? iterator_to_array($value) : $value;
+
+        self::assertSame(['publishedAt', 'title'], $getSetting($settings['filterableAttributes']));
+        self::assertSame(['title'], $getSetting($settings['searchableAttributes']));
+        self::assertSame(['a', 'n', 'the'], $getSetting($settings['stopWords']));
+        self::assertSame(['fantastic' => ['great'], 'great' => ['fantastic']], $getSetting($settings['synonyms']));
+    }
+
+    public function testAlias(): void
+    {
+        $command = $this->application->find('meilisearch:create');
+
+        self::assertSame(['meili:create'], $command->getAliases());
+    }
+}

--- a/tests/Integration/Command/MeilisearchCreateCommandTest.php
+++ b/tests/Integration/Command/MeilisearchCreateCommandTest.php
@@ -44,10 +44,10 @@ final class MeilisearchCreateCommandTest extends BaseKernelTestCase
         if ($updateSettings) {
             $this->assertSame(<<<'EOD'
 Creating index sf_phpunit__posts for Meilisearch\Bundle\Tests\Entity\Post
-Settings updated of "sf_phpunit__posts".
-Settings updated of "sf_phpunit__posts".
-Settings updated of "sf_phpunit__posts".
-Settings updated of "sf_phpunit__posts".
+Setting "stopWords" updated of "sf_phpunit__posts".
+Setting "filterableAttributes" updated of "sf_phpunit__posts".
+Setting "searchCutoffMs" updated of "sf_phpunit__posts".
+Setting "typoTolerance" updated of "sf_phpunit__posts".
 Creating index sf_phpunit__comments for Meilisearch\Bundle\Tests\Entity\Comment
 Creating index sf_phpunit__tags for Meilisearch\Bundle\Tests\Entity\Tag
 Creating index sf_phpunit__tags for Meilisearch\Bundle\Tests\Entity\Link
@@ -56,10 +56,10 @@ Creating index sf_phpunit__pages for Meilisearch\Bundle\Tests\Entity\Page
 Creating index sf_phpunit__self_normalizable for Meilisearch\Bundle\Tests\Entity\SelfNormalizable
 Creating index sf_phpunit__dummy_custom_groups for Meilisearch\Bundle\Tests\Entity\DummyCustomGroups
 Creating index sf_phpunit__dynamic_settings for Meilisearch\Bundle\Tests\Entity\DynamicSettings
-Settings updated of "sf_phpunit__dynamic_settings".
-Settings updated of "sf_phpunit__dynamic_settings".
-Settings updated of "sf_phpunit__dynamic_settings".
-Settings updated of "sf_phpunit__dynamic_settings".
+Setting "filterableAttributes" updated of "sf_phpunit__dynamic_settings".
+Setting "searchableAttributes" updated of "sf_phpunit__dynamic_settings".
+Setting "stopWords" updated of "sf_phpunit__dynamic_settings".
+Setting "synonyms" updated of "sf_phpunit__dynamic_settings".
 Creating index sf_phpunit__aggregated for Meilisearch\Bundle\Tests\Entity\Post
 Creating index sf_phpunit__aggregated for Meilisearch\Bundle\Tests\Entity\Tag
 Done!
@@ -96,10 +96,10 @@ EOD, $createOutput);
 
         $this->assertSame(<<<'EOD'
 Creating index sf_phpunit__posts for Meilisearch\Bundle\Tests\Entity\Post
-Settings updated of "sf_phpunit__posts".
-Settings updated of "sf_phpunit__posts".
-Settings updated of "sf_phpunit__posts".
-Settings updated of "sf_phpunit__posts".
+Setting "stopWords" updated of "sf_phpunit__posts".
+Setting "filterableAttributes" updated of "sf_phpunit__posts".
+Setting "searchCutoffMs" updated of "sf_phpunit__posts".
+Setting "typoTolerance" updated of "sf_phpunit__posts".
 Done!
 
 EOD, $createOutput);
@@ -121,10 +121,10 @@ EOD, $createOutput);
 
         $this->assertSame(<<<'EOD'
 Creating index sf_phpunit__dynamic_settings for Meilisearch\Bundle\Tests\Entity\DynamicSettings
-Settings updated of "sf_phpunit__dynamic_settings".
-Settings updated of "sf_phpunit__dynamic_settings".
-Settings updated of "sf_phpunit__dynamic_settings".
-Settings updated of "sf_phpunit__dynamic_settings".
+Setting "filterableAttributes" updated of "sf_phpunit__dynamic_settings".
+Setting "searchableAttributes" updated of "sf_phpunit__dynamic_settings".
+Setting "stopWords" updated of "sf_phpunit__dynamic_settings".
+Setting "synonyms" updated of "sf_phpunit__dynamic_settings".
 Done!
 
 EOD, $importOutput);

--- a/tests/Integration/Command/MeilisearchDeleteCommandTest.php
+++ b/tests/Integration/Command/MeilisearchDeleteCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Tests\Integration\Command;
+
+use Meilisearch\Bundle\Tests\BaseKernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class MeilisearchDeleteCommandTest extends BaseKernelTestCase
+{
+    protected Application $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->application = new Application(self::createKernel());
+    }
+
+    public function testDeleteWithoutIndices(): void
+    {
+        $clearCommand = $this->application->find('meilisearch:delete');
+        $clearCommandTester = new CommandTester($clearCommand);
+        $clearCommandTester->execute([]);
+
+        $clearOutput = $clearCommandTester->getDisplay();
+
+        $this->assertSame(<<<'EOD'
+Deleted sf_phpunit__posts
+Deleted sf_phpunit__comments
+Deleted sf_phpunit__aggregated
+Deleted sf_phpunit__tags
+Deleted sf_phpunit__discriminator_map
+Deleted sf_phpunit__pages
+Deleted sf_phpunit__self_normalizable
+Deleted sf_phpunit__dummy_custom_groups
+Deleted sf_phpunit__dynamic_settings
+Done!
+
+EOD, $clearOutput);
+    }
+
+    public function testDeleteWithIndices(): void
+    {
+        $clearCommand = $this->application->find('meilisearch:delete');
+        $clearCommandTester = new CommandTester($clearCommand);
+        $clearCommandTester->execute(['--indices' => 'posts']);
+
+        $clearOutput = $clearCommandTester->getDisplay();
+
+        $this->assertSame(<<<'EOD'
+Deleted sf_phpunit__posts
+Done!
+
+EOD, $clearOutput);
+    }
+
+    public function testAlias(): void
+    {
+        $command = $this->application->find('meilisearch:delete');
+
+        self::assertSame(['meili:delete'], $command->getAliases());
+    }
+}

--- a/tests/Integration/Command/MeilisearchImportCommandTest.php
+++ b/tests/Integration/Command/MeilisearchImportCommandTest.php
@@ -338,10 +338,10 @@ EOD, $importOutput);
         $this->assertSame(<<<'EOD'
 Importing for index Meilisearch\Bundle\Tests\Entity\DynamicSettings
 Indexed a batch of 6 / 6 Meilisearch\Bundle\Tests\Entity\DynamicSettings entities into sf_phpunit__dynamic_settings index (6 indexed since start)
-Settings updated of "sf_phpunit__dynamic_settings".
-Settings updated of "sf_phpunit__dynamic_settings".
-Settings updated of "sf_phpunit__dynamic_settings".
-Settings updated of "sf_phpunit__dynamic_settings".
+Setting "filterableAttributes" updated of "sf_phpunit__dynamic_settings".
+Setting "searchableAttributes" updated of "sf_phpunit__dynamic_settings".
+Setting "stopWords" updated of "sf_phpunit__dynamic_settings".
+Setting "synonyms" updated of "sf_phpunit__dynamic_settings".
 Done!
 
 EOD, $importOutput);
@@ -354,6 +354,35 @@ EOD, $importOutput);
         self::assertSame(['title'], $getSetting($settings['searchableAttributes']));
         self::assertSame(['a', 'n', 'the'], $getSetting($settings['stopWords']));
         self::assertSame(['fantastic' => ['great'], 'great' => ['fantastic']], $getSetting($settings['synonyms']));
+    }
+
+    public function testImportUpdatesSettingsOnce(): void
+    {
+        for ($i = 0; $i <= 3; ++$i) {
+            $this->createPost();
+        }
+
+        $this->entityManager->flush();
+
+        $importCommand = $this->application->find('meilisearch:import');
+        $importCommandTester = new CommandTester($importCommand);
+        $importCommandTester->execute(['--indices' => 'posts', '--batch-size' => '2']);
+
+        $importOutput = $importCommandTester->getDisplay();
+
+        $this->assertSame(<<<'EOD'
+Importing for index Meilisearch\Bundle\Tests\Entity\Post
+Indexed a batch of 2 / 2 Meilisearch\Bundle\Tests\Entity\Post entities into sf_phpunit__posts index (2 indexed since start)
+Indexed a batch of 2 / 2 Meilisearch\Bundle\Tests\Entity\Post entities into sf_phpunit__aggregated index (2 indexed since start)
+Indexed a batch of 2 / 2 Meilisearch\Bundle\Tests\Entity\Post entities into sf_phpunit__posts index (4 indexed since start)
+Indexed a batch of 2 / 2 Meilisearch\Bundle\Tests\Entity\Post entities into sf_phpunit__aggregated index (4 indexed since start)
+Setting "stopWords" updated of "sf_phpunit__posts".
+Setting "filterableAttributes" updated of "sf_phpunit__posts".
+Setting "searchCutoffMs" updated of "sf_phpunit__posts".
+Setting "typoTolerance" updated of "sf_phpunit__posts".
+Done!
+
+EOD, $importOutput);
     }
 
     public function testAlias(): void

--- a/tests/Integration/Command/MeilisearchUpdateSettingsCommandTest.php
+++ b/tests/Integration/Command/MeilisearchUpdateSettingsCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Tests\Integration\Command;
+
+use Meilisearch\Bundle\Tests\BaseKernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class MeilisearchUpdateSettingsCommandTest extends BaseKernelTestCase
+{
+    private Application $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->application = new Application(self::createKernel());
+    }
+
+    public function testWithoutIndices(): void
+    {
+        for ($i = 0; $i <= 5; ++$i) {
+            $this->createPost();
+        }
+
+        $importCommand = $this->application->find('meilisearch:update-settings');
+        $importCommandTester = new CommandTester($importCommand);
+        $importCommandTester->execute([]);
+
+        $importOutput = $importCommandTester->getDisplay();
+
+        $this->assertSame(<<<'EOD'
+Setting "stopWords" updated of "sf_phpunit__posts".
+Setting "filterableAttributes" updated of "sf_phpunit__posts".
+Setting "searchCutoffMs" updated of "sf_phpunit__posts".
+Setting "typoTolerance" updated of "sf_phpunit__posts".
+Setting "filterableAttributes" updated of "sf_phpunit__dynamic_settings".
+Setting "searchableAttributes" updated of "sf_phpunit__dynamic_settings".
+Setting "stopWords" updated of "sf_phpunit__dynamic_settings".
+Setting "synonyms" updated of "sf_phpunit__dynamic_settings".
+Done!
+
+EOD, $importOutput);
+    }
+
+    public function testWithIndices(): void
+    {
+        for ($i = 0; $i <= 5; ++$i) {
+            $this->createPost();
+        }
+
+        $importCommand = $this->application->find('meilisearch:update-settings');
+        $importCommandTester = new CommandTester($importCommand);
+        $importCommandTester->execute(['--indices' => 'posts']);
+
+        $importOutput = $importCommandTester->getDisplay();
+
+        $this->assertSame(<<<'EOD'
+Setting "stopWords" updated of "sf_phpunit__posts".
+Setting "filterableAttributes" updated of "sf_phpunit__posts".
+Setting "searchCutoffMs" updated of "sf_phpunit__posts".
+Setting "typoTolerance" updated of "sf_phpunit__posts".
+Done!
+
+EOD, $importOutput);
+    }
+}

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -9,28 +9,21 @@ use Meilisearch\Contracts\Index\TypoTolerance;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * Class SettingsTest.
- */
 class SettingsTest extends BaseKernelTestCase
 {
     private static string $indexName = 'posts';
 
-    public const DEFAULT_RANKING_RULES
-        = [
-            'words',
-            'typo',
-            'proximity',
-            'attribute',
-            'sort',
-            'exactness',
-        ];
+    public const DEFAULT_RANKING_RULES = [
+        'words',
+        'typo',
+        'proximity',
+        'attribute',
+        'sort',
+        'exactness',
+    ];
 
     protected Application $application;
 
-    /**
-     * @throws \Exception
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -52,18 +45,22 @@ class SettingsTest extends BaseKernelTestCase
         $settings = $this->client->index($index)->getSettings();
 
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('Settings updated of "sf_phpunit__posts".', $output);
-        $this->assertNotEmpty($settings['stopWords']);
+
+        $this->assertStringContainsString('Setting "stopWords" updated of "sf_phpunit__posts".', $output);
         $this->assertEquals(['a', 'an', 'the'], $settings['stopWords']);
 
-        $this->assertNotEmpty($settings['filterableAttributes']);
-        $this->assertEquals(['publishedAt', 'title'], $settings['filterableAttributes']);
+        $this->assertStringContainsString('Setting "searchCutoffMs" updated of "sf_phpunit__posts".', $output);
+        $this->assertEquals(1500, $settings['searchCutoffMs']);
 
+        $this->assertStringContainsString('Setting "filterableAttributes" updated of "sf_phpunit__posts".', $output);
+        $this->assertSame(['publishedAt', 'title'], $settings['filterableAttributes']);
+
+        $this->assertStringContainsString('Setting "typoTolerance" updated of "sf_phpunit__posts".', $output);
         $this->assertArrayHasKey('typoTolerance', $settings);
         $this->assertInstanceOf(TypoTolerance::class, $settings['typoTolerance']);
         $this->assertTrue($settings['typoTolerance']['enabled']);
-        $this->assertEquals(['title'], $settings['typoTolerance']['disableOnAttributes']);
-        $this->assertEquals(['york'], $settings['typoTolerance']['disableOnWords']);
-        $this->assertEquals(['oneTypo' => 5, 'twoTypos' => 9], $settings['typoTolerance']['minWordSizeForTypos']);
+        $this->assertSame(['title'], $settings['typoTolerance']['disableOnAttributes']);
+        $this->assertSame(['york'], $settings['typoTolerance']['disableOnWords']);
+        $this->assertSame(['oneTypo' => 5, 'twoTypos' => 9], $settings['typoTolerance']['minWordSizeForTypos']);
     }
 }

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -47,10 +47,10 @@ class SettingsTest extends BaseKernelTestCase
         $output = $commandTester->getDisplay();
 
         $this->assertStringContainsString('Setting "stopWords" updated of "sf_phpunit__posts".', $output);
-        $this->assertEquals(['a', 'an', 'the'], $settings['stopWords']);
+        $this->assertSame(['a', 'an', 'the'], $settings['stopWords']);
 
         $this->assertStringContainsString('Setting "searchCutoffMs" updated of "sf_phpunit__posts".', $output);
-        $this->assertEquals(1500, $settings['searchCutoffMs']);
+        $this->assertSame(1500, $settings['searchCutoffMs']);
 
         $this->assertStringContainsString('Setting "filterableAttributes" updated of "sf_phpunit__posts".', $output);
         $this->assertSame(['publishedAt', 'title'], $settings['filterableAttributes']);


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #255

## What does this PR do?
- When running index create/import commands, it will only update settings once per index;
- Adds `meilisearch:update-settings` command; 
- Splits commands tests into multiple files;
- Enables parallel config for cs fixer;
- Adds settings name to output message: `Settings updated of "posts"` -> `Setting "filterableAttributes" updated of "posts".`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
