### PR TITLE
Fixed Engine::remove() when multiple entities are provided

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -90,9 +90,12 @@ final class Engine
 
         $result = [];
         foreach ($data as $indexUid => $objects) {
-            $result[$indexUid] = $this->client
-                ->index($indexUid)
-                ->deleteDocument(reset($objects));
+            $result[$indexUid] = [];
+            foreach ($objects as $object) {
+                $result[$indexUid][] = $this->client
+                    ->index($indexUid)
+                    ->deleteDocument($object);
+            }
         }
 
         return $result;

--- a/tests/Integration/EngineTest.php
+++ b/tests/Integration/EngineTest.php
@@ -48,4 +48,25 @@ class EngineTest extends BaseKernelTestCase
             $this->assertInstanceOf(ApiException::class, $e);
         }
     }
+
+    public function testRemovingMultipleEntity(): void
+    {
+        $post1 = $this->createSearchablePost();
+        $post2 = $this->createSearchablePost();
+
+        $result = $this->engine->remove([$post1, $post2]);
+
+        $this->assertArrayHasKey('sf_phpunit__posts', $result);
+        $this->assertCount(2, $result['sf_phpunit__posts']);
+
+        $this->waitForAllTasks();
+
+        foreach ([$post1, $post2] as $post) {
+            $searchResult = $this->engine->search('', $post->getIndexUid(), []);
+
+            $this->assertArrayHasKey('hits', $searchResult);
+            $this->assertIsArray($searchResult['hits']);
+            $this->assertEmpty($searchResult['hits']);
+        }
+    }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #341

## What does this PR do?
- fixing the Engine::remove() method which was only removing the first object when multiple objects were provided

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
