### PR TITLE
Clear manager in the import loop (console command)

### DIFF
--- a/src/Command/MeilisearchImportCommand.php
+++ b/src/Command/MeilisearchImportCommand.php
@@ -141,6 +141,8 @@ final class MeilisearchImportCommand extends IndexCommand
                     );
                 }
 
+                $manager->clear();
+
                 ++$page;
             } while (\count($entities) >= $batchSize);
 


### PR DESCRIPTION
Calling $manager->clear() in the import loop to avoid memory problems.

# Pull Request

## Related issue
Fixes #350

## What does this PR do?
- Add a call of $manager->clear() in the import loop to avoir memory problems.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

