### PR TITLE
Fix: Container extension "meili_search" is not registered.

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,7 +13,7 @@ final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder('meili_search');
+        $treeBuilder = new TreeBuilder('meilisearch');
         $rootNode = $treeBuilder->getRootNode();
 
         $rootNode


### PR DESCRIPTION
# Pull Request

## Related issue

https://github.com/meilisearch/meilisearch-symfony/pull/370#issuecomment-2513758648

## What does this PR do?

"meili_search" does not match the bundle name, "meilisearch," which causes some strange bugs, such as this issue.

I have completed a basic smoke test of PHP and YAML. I can confirm that the PHP configuration is now working with the Meilisearch bundle, while the old YAML configuration should function as it did before.

```bash
$ php bin/console meilisearch:import --update-settings
Importing for index App\Entity\Question
Indexed a batch of 70 / 70 App\Entity\Question entities into dev_questions index (70 indexed since start)
Setting "filterableAttributes" updated of "dev_questions".
Setting "sortableAttributes" updated of "dev_questions".
Done!
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
