### PR TITLE
Fix tests for v1.14

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -60,6 +60,12 @@ jobs:
             sf-version: '5.4'
           - php-version: '8.4'
             sf-version: '5.4'
+          - php-version: '7.4'
+            sf-version: '7.2'
+          - php-version: '8.0'
+            sf-version: '7.2'
+          - php-version: '8.1'
+            sf-version: '7.2'
 
     name: integration-tests-against-rc (PHP ${{ matrix.php-version }}) (Symfony ${{ matrix.sf-version }}.*)
     steps:

--- a/tests/Integration/Command/MeilisearchCreateCommandTest.php
+++ b/tests/Integration/Command/MeilisearchCreateCommandTest.php
@@ -133,7 +133,11 @@ EOD, $importOutput);
 
         $getSetting = static fn ($value) => $value instanceof \IteratorAggregate ? iterator_to_array($value) : $value;
 
-        self::assertSame(['publishedAt', 'title'], $getSetting($settings['filterableAttributes']));
+        $filterableAttributes = $getSetting($settings['filterableAttributes']);
+        sort($filterableAttributes);
+        $expected = ['publishedAt', 'title'];
+        sort($expected);
+        self::assertSame($expected, $filterableAttributes);
         self::assertSame(['title'], $getSetting($settings['searchableAttributes']));
         self::assertSame(['a', 'n', 'the'], $getSetting($settings['stopWords']));
         self::assertSame(['fantastic' => ['great'], 'great' => ['fantastic']], $getSetting($settings['synonyms']));

--- a/tests/Integration/Command/MeilisearchImportCommandTest.php
+++ b/tests/Integration/Command/MeilisearchImportCommandTest.php
@@ -406,7 +406,11 @@ EOD, $importOutput);
 
         $getSetting = static fn ($value) => $value instanceof \IteratorAggregate ? iterator_to_array($value) : $value;
 
-        self::assertSame(['publishedAt', 'title'], $getSetting($settings['filterableAttributes']));
+        $filterableAttributes = $getSetting($settings['filterableAttributes']);
+        sort($filterableAttributes);
+        $expected = ['publishedAt', 'title'];
+        sort($expected);
+        self::assertSame($expected, $filterableAttributes);
         self::assertSame(['title'], $getSetting($settings['searchableAttributes']));
         self::assertSame(['a', 'n', 'the'], $getSetting($settings['stopWords']));
         self::assertSame(['fantastic' => ['great'], 'great' => ['fantastic']], $getSetting($settings['synonyms']));

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -53,7 +53,11 @@ final class SettingsTest extends BaseKernelTestCase
         $this->assertSame(1500, $settings['searchCutoffMs']);
 
         $this->assertStringContainsString('Setting "filterableAttributes" updated of "sf_phpunit__posts".', $output);
-        $this->assertSame(['publishedAt', 'title'], $settings['filterableAttributes']);
+        $filterableAttributes = $settings['filterableAttributes'];
+        sort($filterableAttributes);
+        $expected = ['publishedAt', 'title'];
+        sort($expected);
+        $this->assertSame($expected, $filterableAttributes);
 
         $this->assertStringContainsString('Setting "typoTolerance" updated of "sf_phpunit__posts".', $output);
         $this->assertArrayHasKey('typoTolerance', $settings);

--- a/tests/Unit/SerializationTest.php
+++ b/tests/Unit/SerializationTest.php
@@ -16,9 +16,7 @@ final class SerializationTest extends BaseKernelTestCase
     {
         $post = new Post('a simple post', 'some text', $datetime = new \DateTimeImmutable('@1728994403'));
         $idReflection = (new \ReflectionObject($post))->getProperty('id');
-        if (PHP_VERSION_ID < 80000) {
-            $idReflection->setAccessible(true);
-        }
+        $idReflection->setAccessible(true);
         $idReflection->setValue($post, 12);
 
         $comment = new Comment($post, 'a great comment', $datetime);

--- a/tests/Unit/SerializationTest.php
+++ b/tests/Unit/SerializationTest.php
@@ -16,7 +16,9 @@ final class SerializationTest extends BaseKernelTestCase
     {
         $post = new Post('a simple post', 'some text', $datetime = new \DateTimeImmutable('@1728994403'));
         $idReflection = (new \ReflectionObject($post))->getProperty('id');
-        $idReflection->setAccessible(true);
+        if (PHP_VERSION_ID < 80000) {
+            $idReflection->setAccessible(true);
+        }
         $idReflection->setValue($post, 12);
 
         $comment = new Comment($post, 'a great comment', $datetime);


### PR DESCRIPTION
# Pull Request

## Related issue

The tests against Meilisearch v1.14 are failing due to assertions on filterable attributes.

When the order of the filterable attributes changes in the API response, the tests fail. See [failing tests](https://github.com/meilisearch/meilisearch/actions/runs/13919694563/job/38949844525)

@dureuill confirmed that the attribute order was never guaranteed in the first place, so we should make this test more permissive by only checking the attribute presence, not their order.

## What does this PR do?

- Update the tests to only check the presence of the filterable attributes, not their order
- Update `pre-release-tests.yml` to use the same exclusion combinations as `tests.yml` (it was leading to incompatible symfony + PHP versions)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
