### PR TITLE
Fix deprecations in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,8 @@ on:
       - trying
       - staging
       - main
+  schedule:
+    - cron: '0 3 * * 1'
 
 env:
   fail-fast: true

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -23,4 +23,6 @@ return (new PhpCsFixer\Config())
         'no_superfluous_phpdoc_tags' => false,
         // @todo: when we'll support only PHP 8.0 and upper, we can enable `parameters` for `trailing_comma_in_multiline` rule
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays', 'match'/* , 'parameters' */]],
+        // @todo: when we'll support only PHP 8.0 and upper, we can enable this
+        'get_class_to_class_keyword' => false,
     ]);

--- a/src/Services/MeilisearchService.php
+++ b/src/Services/MeilisearchService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Meilisearch\Bundle\Services;
 
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\Mapping\LegacyReflectionFields;
 use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
 use Doctrine\Persistence\ObjectManager;
 use Meilisearch\Bundle\Collection;
@@ -374,6 +375,11 @@ final class MeilisearchService implements SearchService
         static $resolver;
 
         $resolver ??= (function () {
+            // Native lazy objects compatibility
+            if (PHP_VERSION_ID >= 80400 && class_exists(LegacyReflectionFields::class)) {
+                return fn (object $object) => \get_class($object);
+            }
+
             // Doctrine ORM v3+ compatibility
             if (class_exists(DefaultProxyClassNameResolver::class)) {
                 return fn (object $object) => DefaultProxyClassNameResolver::getClass($object);

--- a/tests/Integration/AggregatorTest.php
+++ b/tests/Integration/AggregatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Meilisearch\Bundle\Tests\Integration;
 
+use Doctrine\ORM\Mapping\LegacyReflectionFields;
 use Doctrine\Persistence\Proxy;
 use Meilisearch\Bundle\Exception\EntityNotFoundInObjectID;
 use Meilisearch\Bundle\Exception\InvalidEntityForAggregator;
@@ -35,6 +36,10 @@ final class AggregatorTest extends BaseKernelTestCase
 
     public function testAggregatorProxyClass(): void
     {
+        if (class_exists(LegacyReflectionFields::class)) {
+            $this->markTestSkipped('Skipping, because proxies are not wrapped anymore with lazy native objects.');
+        }
+
         $this->entityManager->persist($post = new Post());
         $this->entityManager->flush();
         $postId = $post->getId();

--- a/tests/Kernel.php
+++ b/tests/Kernel.php
@@ -7,6 +7,7 @@ namespace Meilisearch\Bundle\Tests;
 use Doctrine\Bundle\DoctrineBundle\ConnectionFactory;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Mapping\LegacyReflectionFields;
 use Meilisearch\Bundle\MeilisearchBundle;
 use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -29,7 +30,11 @@ final class Kernel extends HttpKernel
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         if (PHP_VERSION_ID >= 80000) {
-            $loader->load(__DIR__.'/config/config.yaml');
+            if (class_exists(LegacyReflectionFields::class) && PHP_VERSION_ID >= 80400) {
+                $loader->load(__DIR__.'/config/config.yaml');
+            } else {
+                $loader->load(__DIR__.'/config/config_old_proxy.yaml');
+            }
         } else {
             $loader->load(__DIR__.'/config/config_php7.yaml');
         }

--- a/tests/baseline-ignore
+++ b/tests/baseline-ignore
@@ -1,3 +1,9 @@
 %Method "ArrayAccess::offsetGet\(\)" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Meilisearch\\Contracts\\Data" now to avoid errors or add an explicit @return annotation to suppress this message.%
 %Since symfony/var-exporter 7.3: The "Symfony\\Component\\VarExporter\\LazyGhostTrait" trait is deprecated, use native lazy objects instead.%
 %Since symfony/var-exporter 7.3: Using ProxyHelper::generateLazyGhost\(\) is deprecated, use native lazy objects instead.%
+%Class "Doctrine\\ORM\\Proxy\\Autoloader" is deprecated. Use native lazy objects instead.%
+%Calling Doctrine\\ORM\\Configuration::setProxyDir is deprecated and will not be possible in Doctrine ORM 4.0%
+%Calling Doctrine\\ORM\\Configuration::getProxyDir is deprecated and will not be possible in Doctrine ORM 4.0%
+%Calling Doctrine\\ORM\\Configuration::setAutoGenerateProxyClasses is deprecated and will not be possible in Doctrine ORM 4.0%
+%Calling Doctrine\\ORM\\Configuration::getAutoGenerateProxyClasses is deprecated and will not be possible in Doctrine ORM 4.0%
+%Calling Doctrine\\ORM\\Configuration::setProxyNamespace is deprecated and will not be possible in Doctrine ORM 4.0%

--- a/tests/config/config_old_proxy.yaml
+++ b/tests/config/config_old_proxy.yaml
@@ -13,8 +13,7 @@ doctrine:
         types:
             dummy_object_id: Meilisearch\Bundle\Tests\Dbal\Type\DummyObjectIdType
     orm:
-        enable_native_lazy_objects: true
-        auto_generate_proxy_classes: false
+        auto_generate_proxy_classes: true
         report_fields_where_declared: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: true


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #389

## What does this PR do?
- Fixes deprecations and CI run
- Add's cron to run once per week to spot deprecations/errors earlier

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for native lazy objects in Doctrine ORM when compatible, with automatic configuration adjustments based on PHP version and environment.
  * Introduced a new configuration file to ensure compatibility with older proxy mechanisms.

* **Bug Fixes**
  * Improved compatibility checks to ensure correct class resolution and configuration loading across different Doctrine ORM and PHP versions.

* **Tests**
  * Updated tests to conditionally skip scenarios incompatible with native lazy objects.
  * Suppressed deprecation warnings related to Doctrine ORM proxies in test outputs.

* **Chores**
  * Scheduled automated test runs every Monday at 03:00 UTC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->